### PR TITLE
type bind calls properly and re-generate wrappers

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
   },
   "homepage": "https://github.com/PolymathNetwork/polymath-abi-wrappers/blob/master/README.md",
   "devDependencies": {
-    "@0x/abi-gen": "^1.0.19",
-    "@0x/types": "^1.4.1",
+    "@0x/abi-gen": "1.0.19",
+    "@0x/types": "1.4.1",
     "@types/lodash": "^4.14.119",
+    "@types/node": "^10.12.18",
     "polymath-contract-artifacts": "git://github.com/PolymathNetwork/polymath-contract-artifacts.git#v2.1.0-beta",
     "shx": "^0.2.2"
   },
@@ -41,6 +42,7 @@
     "@0x/sol-compiler": "^1.1.16",
     "@0x/utils": "^2.0.8",
     "@0x/web3-wrapper": "^3.2.1",
+    "typescript": "3.2.1",
     "ethereum-types": "^1.1.4",
     "ethers": "^4.0.20",
     "lodash": "^4.17.11"

--- a/partials/tx.handlebars
+++ b/partials/tx.handlebars
@@ -20,7 +20,7 @@ public {{this.tsName}} = {
                 data: encodedData,
             },
             self._web3Wrapper.getContractDefaults(),
-            self.{{this.tsName}}.estimateGasAsync.bind(
+            self.{{this.tsName}}.estimateGasAsync.bind<{{contractName}}Contract, any, Promise<number>>(
                 self,
                 {{> params inputs=inputs}}
             ),

--- a/src/generated-wrappers/capped_s_t_o.ts
+++ b/src/generated-wrappers/capped_s_t_o.ts
@@ -189,7 +189,7 @@ export class CappedSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.unpause.estimateGasAsync.bind(
+                self.unpause.estimateGasAsync.bind<CappedSTOContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -332,7 +332,7 @@ export class CappedSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.takeFee.estimateGasAsync.bind(
+                self.takeFee.estimateGasAsync.bind<CappedSTOContract, any, Promise<number>>(
                     self,
                     _amount
                 ),
@@ -549,7 +549,7 @@ export class CappedSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pause.estimateGasAsync.bind(
+                self.pause.estimateGasAsync.bind<CappedSTOContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -632,7 +632,7 @@ export class CappedSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.reclaimERC20.estimateGasAsync.bind(
+                self.reclaimERC20.estimateGasAsync.bind<CappedSTOContract, any, Promise<number>>(
                     self,
                     _tokenContract
                 ),
@@ -1009,7 +1009,7 @@ export class CappedSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.configure.estimateGasAsync.bind(
+                self.configure.estimateGasAsync.bind<CappedSTOContract, any, Promise<number>>(
                     self,
                     _startTime,
                     _endTime,
@@ -1206,7 +1206,7 @@ export class CappedSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeAllowBeneficialInvestments.estimateGasAsync.bind(
+                self.changeAllowBeneficialInvestments.estimateGasAsync.bind<CappedSTOContract, any, Promise<number>>(
                     self,
                     _allowBeneficialInvestments
                 ),
@@ -1303,7 +1303,7 @@ export class CappedSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.buyTokens.estimateGasAsync.bind(
+                self.buyTokens.estimateGasAsync.bind<CappedSTOContract, any, Promise<number>>(
                     self,
                     _beneficiary
                 ),
@@ -1400,7 +1400,7 @@ export class CappedSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.buyTokensWithPoly.estimateGasAsync.bind(
+                self.buyTokensWithPoly.estimateGasAsync.bind<CappedSTOContract, any, Promise<number>>(
                     self,
                     _investedPOLY
                 ),

--- a/src/generated-wrappers/capped_s_t_o_factory.ts
+++ b/src/generated-wrappers/capped_s_t_o_factory.ts
@@ -28,6 +28,7 @@ export enum CappedSTOFactoryEvents {
     ChangeSTVersionBound = 'ChangeSTVersionBound',
     OwnershipRenounced = 'OwnershipRenounced',
     OwnershipTransferred = 'OwnershipTransferred',
+    GenerateModuleFromFactory = 'GenerateModuleFromFactory',
 }
 
 export interface CappedSTOFactoryChangeFactorySetupFeeEventArgs extends DecodedLogArgs {
@@ -197,7 +198,7 @@ export class CappedSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeTitle.estimateGasAsync.bind(
+                self.changeTitle.estimateGasAsync.bind<CappedSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newTitle
                 ),
@@ -294,7 +295,7 @@ export class CappedSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeFactorySubscriptionFee.estimateGasAsync.bind(
+                self.changeFactorySubscriptionFee.estimateGasAsync.bind<CappedSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newSubscriptionCost
                 ),
@@ -451,7 +452,7 @@ export class CappedSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeFactorySetupFee.estimateGasAsync.bind(
+                self.changeFactorySetupFee.estimateGasAsync.bind<CappedSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newSetupCost
                 ),
@@ -548,7 +549,7 @@ export class CappedSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeVersion.estimateGasAsync.bind(
+                self.changeVersion.estimateGasAsync.bind<CappedSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newVersion
                 ),
@@ -670,7 +671,7 @@ export class CappedSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.renounceOwnership.estimateGasAsync.bind(
+                self.renounceOwnership.estimateGasAsync.bind<CappedSTOFactoryContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -843,7 +844,7 @@ export class CappedSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeName.estimateGasAsync.bind(
+                self.changeName.estimateGasAsync.bind<CappedSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newName
                 ),
@@ -1000,7 +1001,7 @@ export class CappedSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeFactoryUsageFee.estimateGasAsync.bind(
+                self.changeFactoryUsageFee.estimateGasAsync.bind<CappedSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newUsageCost
                 ),
@@ -1127,7 +1128,7 @@ export class CappedSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeDescription.estimateGasAsync.bind(
+                self.changeDescription.estimateGasAsync.bind<CappedSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newDesc
                 ),
@@ -1224,7 +1225,7 @@ export class CappedSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
+                self.transferOwnership.estimateGasAsync.bind<CappedSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newOwner
                 ),
@@ -1356,7 +1357,7 @@ export class CappedSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeSTVersionBounds.estimateGasAsync.bind(
+                self.changeSTVersionBounds.estimateGasAsync.bind<CappedSTOFactoryContract, any, Promise<number>>(
                     self,
                     _boundType,
                     _newVersion
@@ -1467,7 +1468,7 @@ export class CappedSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.deploy.estimateGasAsync.bind(
+                self.deploy.estimateGasAsync.bind<CappedSTOFactoryContract, any, Promise<number>>(
                     self,
                     _data
                 ),

--- a/src/generated-wrappers/erc20_dividend_checkpoint.ts
+++ b/src/generated-wrappers/erc20_dividend_checkpoint.ts
@@ -112,7 +112,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.setWithholdingFixed.estimateGasAsync.bind(
+                self.setWithholdingFixed.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _investors,
                     _withholding
@@ -283,7 +283,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pullDividendPayment.estimateGasAsync.bind(
+                self.pullDividendPayment.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _dividendIndex
                 ),
@@ -450,7 +450,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pushDividendPaymentToAddresses.estimateGasAsync.bind(
+                self.pushDividendPaymentToAddresses.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _dividendIndex,
                     _payees
@@ -666,7 +666,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.takeFee.estimateGasAsync.bind(
+                self.takeFee.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _amount
                 ),
@@ -898,7 +898,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.setWithholding.estimateGasAsync.bind(
+                self.setWithholding.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _investors,
                     _withholding
@@ -1169,7 +1169,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.setDefaultExcluded.estimateGasAsync.bind(
+                self.setDefaultExcluded.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _excluded
                 ),
@@ -1306,7 +1306,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pushDividendPayment.estimateGasAsync.bind(
+                self.pushDividendPayment.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _dividendIndex,
                     _start,
@@ -1456,7 +1456,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.createCheckpoint.estimateGasAsync.bind(
+                self.createCheckpoint.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -1559,7 +1559,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.createDividend.estimateGasAsync.bind(
+                self.createDividend.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _maturity,
                     _expiry,
@@ -1737,7 +1737,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.createDividendWithCheckpoint.estimateGasAsync.bind(
+                self.createDividendWithCheckpoint.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _maturity,
                     _expiry,
@@ -1929,7 +1929,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.createDividendWithExclusions.estimateGasAsync.bind(
+                self.createDividendWithExclusions.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _maturity,
                     _expiry,
@@ -2126,7 +2126,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.createDividendWithCheckpointAndExclusions.estimateGasAsync.bind(
+                self.createDividendWithCheckpointAndExclusions.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _maturity,
                     _expiry,
@@ -2307,7 +2307,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.reclaimDividend.estimateGasAsync.bind(
+                self.reclaimDividend.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _dividendIndex
                 ),
@@ -2404,7 +2404,7 @@ export class ERC20DividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.withdrawWithholding.estimateGasAsync.bind(
+                self.withdrawWithholding.estimateGasAsync.bind<ERC20DividendCheckpointContract, any, Promise<number>>(
                     self,
                     _dividendIndex
                 ),

--- a/src/generated-wrappers/ether_dividend_checkpoint.ts
+++ b/src/generated-wrappers/ether_dividend_checkpoint.ts
@@ -117,7 +117,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.setWithholdingFixed.estimateGasAsync.bind(
+                self.setWithholdingFixed.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _investors,
                     _withholding
@@ -288,7 +288,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pullDividendPayment.estimateGasAsync.bind(
+                self.pullDividendPayment.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _dividendIndex
                 ),
@@ -455,7 +455,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pushDividendPaymentToAddresses.estimateGasAsync.bind(
+                self.pushDividendPaymentToAddresses.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _dividendIndex,
                     _payees
@@ -671,7 +671,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.takeFee.estimateGasAsync.bind(
+                self.takeFee.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _amount
                 ),
@@ -903,7 +903,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.setWithholding.estimateGasAsync.bind(
+                self.setWithholding.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _investors,
                     _withholding
@@ -1139,7 +1139,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.setDefaultExcluded.estimateGasAsync.bind(
+                self.setDefaultExcluded.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _excluded
                 ),
@@ -1276,7 +1276,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pushDividendPayment.estimateGasAsync.bind(
+                self.pushDividendPayment.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _dividendIndex,
                     _start,
@@ -1426,7 +1426,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.createCheckpoint.estimateGasAsync.bind(
+                self.createCheckpoint.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -1519,7 +1519,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.createDividend.estimateGasAsync.bind(
+                self.createDividend.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _maturity,
                     _expiry,
@@ -1659,7 +1659,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.createDividendWithCheckpoint.estimateGasAsync.bind(
+                self.createDividendWithCheckpoint.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _maturity,
                     _expiry,
@@ -1813,7 +1813,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.createDividendWithExclusions.estimateGasAsync.bind(
+                self.createDividendWithExclusions.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _maturity,
                     _expiry,
@@ -1972,7 +1972,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.createDividendWithCheckpointAndExclusions.estimateGasAsync.bind(
+                self.createDividendWithCheckpointAndExclusions.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _maturity,
                     _expiry,
@@ -2125,7 +2125,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.reclaimDividend.estimateGasAsync.bind(
+                self.reclaimDividend.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _dividendIndex
                 ),
@@ -2222,7 +2222,7 @@ export class EtherDividendCheckpointContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.withdrawWithholding.estimateGasAsync.bind(
+                self.withdrawWithholding.estimateGasAsync.bind<EtherDividendCheckpointContract, any, Promise<number>>(
                     self,
                     _dividendIndex
                 ),

--- a/src/generated-wrappers/feature_registry.ts
+++ b/src/generated-wrappers/feature_registry.ts
@@ -56,7 +56,7 @@ export class FeatureRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.renounceOwnership.estimateGasAsync.bind(
+                self.renounceOwnership.estimateGasAsync.bind<FeatureRegistryContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -139,7 +139,7 @@ export class FeatureRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.reclaimERC20.estimateGasAsync.bind(
+                self.reclaimERC20.estimateGasAsync.bind<FeatureRegistryContract, any, Promise<number>>(
                     self,
                     _tokenContract
                 ),
@@ -301,7 +301,7 @@ export class FeatureRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
+                self.transferOwnership.estimateGasAsync.bind<FeatureRegistryContract, any, Promise<number>>(
                     self,
                     _newOwner
                 ),
@@ -438,7 +438,7 @@ export class FeatureRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.setFeatureStatus.estimateGasAsync.bind(
+                self.setFeatureStatus.estimateGasAsync.bind<FeatureRegistryContract, any, Promise<number>>(
                     self,
                     _nameKey,
                     _newStatus

--- a/src/generated-wrappers/general_permission_manager.ts
+++ b/src/generated-wrappers/general_permission_manager.ts
@@ -104,7 +104,7 @@ export class GeneralPermissionManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.takeFee.estimateGasAsync.bind(
+                self.takeFee.estimateGasAsync.bind<GeneralPermissionManagerContract, any, Promise<number>>(
                     self,
                     _amount
                 ),
@@ -501,7 +501,7 @@ export class GeneralPermissionManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.addDelegate.estimateGasAsync.bind(
+                self.addDelegate.estimateGasAsync.bind<GeneralPermissionManagerContract, any, Promise<number>>(
                     self,
                     _delegate,
                     _details
@@ -612,7 +612,7 @@ export class GeneralPermissionManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.deleteDelegate.estimateGasAsync.bind(
+                self.deleteDelegate.estimateGasAsync.bind<GeneralPermissionManagerContract, any, Promise<number>>(
                     self,
                     _delegate
                 ),
@@ -759,7 +759,7 @@ export class GeneralPermissionManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changePermission.estimateGasAsync.bind(
+                self.changePermission.estimateGasAsync.bind<GeneralPermissionManagerContract, any, Promise<number>>(
                     self,
                     _delegate,
                     _module,
@@ -913,7 +913,7 @@ export class GeneralPermissionManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changePermissionMulti.estimateGasAsync.bind(
+                self.changePermissionMulti.estimateGasAsync.bind<GeneralPermissionManagerContract, any, Promise<number>>(
                     self,
                     _delegate,
                     _modules,

--- a/src/generated-wrappers/general_transfer_manager.ts
+++ b/src/generated-wrappers/general_transfer_manager.ts
@@ -193,7 +193,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.unpause.estimateGasAsync.bind(
+                self.unpause.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -341,7 +341,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.takeFee.estimateGasAsync.bind(
+                self.takeFee.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                     _amount
                 ),
@@ -463,7 +463,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pause.estimateGasAsync.bind(
+                self.pause.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -926,7 +926,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeDefaults.estimateGasAsync.bind(
+                self.changeDefaults.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                     _defaultFromTime,
                     _defaultToTime
@@ -1037,7 +1037,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeIssuanceAddress.estimateGasAsync.bind(
+                self.changeIssuanceAddress.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                     _issuanceAddress
                 ),
@@ -1134,7 +1134,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeSigningAddress.estimateGasAsync.bind(
+                self.changeSigningAddress.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                     _signingAddress
                 ),
@@ -1231,7 +1231,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeAllowAllTransfers.estimateGasAsync.bind(
+                self.changeAllowAllTransfers.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                     _allowAllTransfers
                 ),
@@ -1328,7 +1328,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeAllowAllWhitelistTransfers.estimateGasAsync.bind(
+                self.changeAllowAllWhitelistTransfers.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                     _allowAllWhitelistTransfers
                 ),
@@ -1425,7 +1425,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeAllowAllWhitelistIssuances.estimateGasAsync.bind(
+                self.changeAllowAllWhitelistIssuances.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                     _allowAllWhitelistIssuances
                 ),
@@ -1522,7 +1522,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeAllowAllBurnTransfers.estimateGasAsync.bind(
+                self.changeAllowAllBurnTransfers.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                     _allowAllBurnTransfers
                 ),
@@ -1639,7 +1639,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.verifyTransfer.estimateGasAsync.bind(
+                self.verifyTransfer.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -1812,7 +1812,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.modifyWhitelist.estimateGasAsync.bind(
+                self.modifyWhitelist.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                     _investor,
                     _fromTime,
@@ -1985,7 +1985,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.modifyWhitelistMulti.estimateGasAsync.bind(
+                self.modifyWhitelistMulti.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                     _investors,
                     _fromTimes,
@@ -2188,7 +2188,7 @@ export class GeneralTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.modifyWhitelistSigned.estimateGasAsync.bind(
+                self.modifyWhitelistSigned.estimateGasAsync.bind<GeneralTransferManagerContract, any, Promise<number>>(
                     self,
                     _investor,
                     _fromTime,

--- a/src/generated-wrappers/i_module.ts
+++ b/src/generated-wrappers/i_module.ts
@@ -96,7 +96,7 @@ export class IModuleContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.takeFee.estimateGasAsync.bind(
+                self.takeFee.estimateGasAsync.bind<IModuleContract, any, Promise<number>>(
                     self,
                     _amount
                 ),

--- a/src/generated-wrappers/i_transfer_manager.ts
+++ b/src/generated-wrappers/i_transfer_manager.ts
@@ -113,7 +113,7 @@ export class ITransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.takeFee.estimateGasAsync.bind(
+                self.takeFee.estimateGasAsync.bind<ITransferManagerContract, any, Promise<number>>(
                     self,
                     _amount
                 ),
@@ -380,7 +380,7 @@ export class ITransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.verifyTransfer.estimateGasAsync.bind(
+                self.verifyTransfer.estimateGasAsync.bind<ITransferManagerContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -528,7 +528,7 @@ export class ITransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.unpause.estimateGasAsync.bind(
+                self.unpause.estimateGasAsync.bind<ITransferManagerContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -606,7 +606,7 @@ export class ITransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pause.estimateGasAsync.bind(
+                self.pause.estimateGasAsync.bind<ITransferManagerContract, any, Promise<number>>(
                     self,
                 ),
             );

--- a/src/generated-wrappers/isto.ts
+++ b/src/generated-wrappers/isto.ts
@@ -179,7 +179,7 @@ export class ISTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.takeFee.estimateGasAsync.bind(
+                self.takeFee.estimateGasAsync.bind<ISTOContract, any, Promise<number>>(
                     self,
                     _amount
                 ),
@@ -616,7 +616,7 @@ export class ISTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.reclaimERC20.estimateGasAsync.bind(
+                self.reclaimERC20.estimateGasAsync.bind<ISTOContract, any, Promise<number>>(
                     self,
                     _tokenContract
                 ),
@@ -773,7 +773,7 @@ export class ISTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pause.estimateGasAsync.bind(
+                self.pause.estimateGasAsync.bind<ISTOContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -851,7 +851,7 @@ export class ISTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.unpause.estimateGasAsync.bind(
+                self.unpause.estimateGasAsync.bind<ISTOContract, any, Promise<number>>(
                     self,
                 ),
             );

--- a/src/generated-wrappers/manual_approval_transfer_manager.ts
+++ b/src/generated-wrappers/manual_approval_transfer_manager.ts
@@ -78,7 +78,7 @@ export class ManualApprovalTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.unpause.estimateGasAsync.bind(
+                self.unpause.estimateGasAsync.bind<ManualApprovalTransferManagerContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -231,7 +231,7 @@ export class ManualApprovalTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.takeFee.estimateGasAsync.bind(
+                self.takeFee.estimateGasAsync.bind<ManualApprovalTransferManagerContract, any, Promise<number>>(
                     self,
                     _amount
                 ),
@@ -388,7 +388,7 @@ export class ManualApprovalTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pause.estimateGasAsync.bind(
+                self.pause.estimateGasAsync.bind<ManualApprovalTransferManagerContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -701,7 +701,7 @@ export class ManualApprovalTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.verifyTransfer.estimateGasAsync.bind(
+                self.verifyTransfer.estimateGasAsync.bind<ManualApprovalTransferManagerContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -874,7 +874,7 @@ export class ManualApprovalTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.addManualApproval.estimateGasAsync.bind(
+                self.addManualApproval.estimateGasAsync.bind<ManualApprovalTransferManagerContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -1047,7 +1047,7 @@ export class ManualApprovalTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.addManualApprovalMulti.estimateGasAsync.bind(
+                self.addManualApprovalMulti.estimateGasAsync.bind<ManualApprovalTransferManagerContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -1225,7 +1225,7 @@ export class ManualApprovalTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.modifyManualApproval.estimateGasAsync.bind(
+                self.modifyManualApproval.estimateGasAsync.bind<ManualApprovalTransferManagerContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -1417,7 +1417,7 @@ export class ManualApprovalTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.modifyManualApprovalMulti.estimateGasAsync.bind(
+                self.modifyManualApprovalMulti.estimateGasAsync.bind<ManualApprovalTransferManagerContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -1589,7 +1589,7 @@ export class ManualApprovalTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.revokeManualApproval.estimateGasAsync.bind(
+                self.revokeManualApproval.estimateGasAsync.bind<ManualApprovalTransferManagerContract, any, Promise<number>>(
                     self,
                     _from,
                     _to
@@ -1705,7 +1705,7 @@ export class ManualApprovalTransferManagerContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.revokeManualApprovalMulti.estimateGasAsync.bind(
+                self.revokeManualApprovalMulti.estimateGasAsync.bind<ManualApprovalTransferManagerContract, any, Promise<number>>(
                     self,
                     _from,
                     _to

--- a/src/generated-wrappers/module_factory.ts
+++ b/src/generated-wrappers/module_factory.ts
@@ -28,6 +28,7 @@ export enum ModuleFactoryEvents {
     ChangeSTVersionBound = 'ChangeSTVersionBound',
     OwnershipRenounced = 'OwnershipRenounced',
     OwnershipTransferred = 'OwnershipTransferred',
+    GenerateModuleFromFactory = 'GenerateModuleFromFactory',
 }
 
 export interface ModuleFactoryChangeFactorySetupFeeEventArgs extends DecodedLogArgs {
@@ -107,7 +108,7 @@ export class ModuleFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.deploy.estimateGasAsync.bind(
+                self.deploy.estimateGasAsync.bind<ModuleFactoryContract, any, Promise<number>>(
                     self,
                     _data
                 ),
@@ -349,7 +350,7 @@ export class ModuleFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.renounceOwnership.estimateGasAsync.bind(
+                self.renounceOwnership.estimateGasAsync.bind<ModuleFactoryContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -642,7 +643,7 @@ export class ModuleFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
+                self.transferOwnership.estimateGasAsync.bind<ModuleFactoryContract, any, Promise<number>>(
                     self,
                     _newOwner
                 ),
@@ -739,7 +740,7 @@ export class ModuleFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeFactorySetupFee.estimateGasAsync.bind(
+                self.changeFactorySetupFee.estimateGasAsync.bind<ModuleFactoryContract, any, Promise<number>>(
                     self,
                     _newSetupCost
                 ),
@@ -836,7 +837,7 @@ export class ModuleFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeFactoryUsageFee.estimateGasAsync.bind(
+                self.changeFactoryUsageFee.estimateGasAsync.bind<ModuleFactoryContract, any, Promise<number>>(
                     self,
                     _newUsageCost
                 ),
@@ -933,7 +934,7 @@ export class ModuleFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeFactorySubscriptionFee.estimateGasAsync.bind(
+                self.changeFactorySubscriptionFee.estimateGasAsync.bind<ModuleFactoryContract, any, Promise<number>>(
                     self,
                     _newSubscriptionCost
                 ),
@@ -1030,7 +1031,7 @@ export class ModuleFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeTitle.estimateGasAsync.bind(
+                self.changeTitle.estimateGasAsync.bind<ModuleFactoryContract, any, Promise<number>>(
                     self,
                     _newTitle
                 ),
@@ -1127,7 +1128,7 @@ export class ModuleFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeDescription.estimateGasAsync.bind(
+                self.changeDescription.estimateGasAsync.bind<ModuleFactoryContract, any, Promise<number>>(
                     self,
                     _newDesc
                 ),
@@ -1224,7 +1225,7 @@ export class ModuleFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeName.estimateGasAsync.bind(
+                self.changeName.estimateGasAsync.bind<ModuleFactoryContract, any, Promise<number>>(
                     self,
                     _newName
                 ),
@@ -1321,7 +1322,7 @@ export class ModuleFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeVersion.estimateGasAsync.bind(
+                self.changeVersion.estimateGasAsync.bind<ModuleFactoryContract, any, Promise<number>>(
                     self,
                     _newVersion
                 ),
@@ -1423,7 +1424,7 @@ export class ModuleFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeSTVersionBounds.estimateGasAsync.bind(
+                self.changeSTVersionBounds.estimateGasAsync.bind<ModuleFactoryContract, any, Promise<number>>(
                     self,
                     _boundType,
                     _newVersion

--- a/src/generated-wrappers/module_registry.ts
+++ b/src/generated-wrappers/module_registry.ts
@@ -303,7 +303,7 @@ export class ModuleRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.initialize.estimateGasAsync.bind(
+                self.initialize.estimateGasAsync.bind<ModuleRegistryContract, any, Promise<number>>(
                     self,
                     _polymathRegistry,
                     _owner
@@ -414,7 +414,7 @@ export class ModuleRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.useModule.estimateGasAsync.bind(
+                self.useModule.estimateGasAsync.bind<ModuleRegistryContract, any, Promise<number>>(
                     self,
                     _moduleFactory
                 ),
@@ -511,7 +511,7 @@ export class ModuleRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.registerModule.estimateGasAsync.bind(
+                self.registerModule.estimateGasAsync.bind<ModuleRegistryContract, any, Promise<number>>(
                     self,
                     _moduleFactory
                 ),
@@ -608,7 +608,7 @@ export class ModuleRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.removeModule.estimateGasAsync.bind(
+                self.removeModule.estimateGasAsync.bind<ModuleRegistryContract, any, Promise<number>>(
                     self,
                     _moduleFactory
                 ),
@@ -710,7 +710,7 @@ export class ModuleRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.verifyModule.estimateGasAsync.bind(
+                self.verifyModule.estimateGasAsync.bind<ModuleRegistryContract, any, Promise<number>>(
                     self,
                     _moduleFactory,
                     _verified
@@ -1006,7 +1006,7 @@ export class ModuleRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.reclaimERC20.estimateGasAsync.bind(
+                self.reclaimERC20.estimateGasAsync.bind<ModuleRegistryContract, any, Promise<number>>(
                     self,
                     _tokenContract
                 ),
@@ -1098,7 +1098,7 @@ export class ModuleRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pause.estimateGasAsync.bind(
+                self.pause.estimateGasAsync.bind<ModuleRegistryContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -1176,7 +1176,7 @@ export class ModuleRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.unpause.estimateGasAsync.bind(
+                self.unpause.estimateGasAsync.bind<ModuleRegistryContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -1254,7 +1254,7 @@ export class ModuleRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.updateFromRegistry.estimateGasAsync.bind(
+                self.updateFromRegistry.estimateGasAsync.bind<ModuleRegistryContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -1337,7 +1337,7 @@ export class ModuleRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
+                self.transferOwnership.estimateGasAsync.bind<ModuleRegistryContract, any, Promise<number>>(
                     self,
                     _newOwner
                 ),

--- a/src/generated-wrappers/ownable.ts
+++ b/src/generated-wrappers/ownable.ts
@@ -79,7 +79,7 @@ export class OwnableContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.renounceOwnership.estimateGasAsync.bind(
+                self.renounceOwnership.estimateGasAsync.bind<OwnableContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -162,7 +162,7 @@ export class OwnableContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
+                self.transferOwnership.estimateGasAsync.bind<OwnableContract, any, Promise<number>>(
                     self,
                     _newOwner
                 ),

--- a/src/generated-wrappers/poly_token.ts
+++ b/src/generated-wrappers/poly_token.ts
@@ -287,7 +287,7 @@ export class PolyTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transfer.estimateGasAsync.bind(
+                self.transfer.estimateGasAsync.bind<PolyTokenContract, any, Promise<number>>(
                     self,
                     _to,
                     _value
@@ -408,7 +408,7 @@ export class PolyTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
+                self.transferFrom.estimateGasAsync.bind<PolyTokenContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -538,7 +538,7 @@ export class PolyTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
+                self.approve.estimateGasAsync.bind<PolyTokenContract, any, Promise<number>>(
                     self,
                     _spender,
                     _value
@@ -654,7 +654,7 @@ export class PolyTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.increaseApproval.estimateGasAsync.bind(
+                self.increaseApproval.estimateGasAsync.bind<PolyTokenContract, any, Promise<number>>(
                     self,
                     _spender,
                     _addedValue
@@ -770,7 +770,7 @@ export class PolyTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.decreaseApproval.estimateGasAsync.bind(
+                self.decreaseApproval.estimateGasAsync.bind<PolyTokenContract, any, Promise<number>>(
                     self,
                     _spender,
                     _subtractedValue

--- a/src/generated-wrappers/poly_token_faucet.ts
+++ b/src/generated-wrappers/poly_token_faucet.ts
@@ -152,7 +152,7 @@ export class PolyTokenFaucetContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.getTokens.estimateGasAsync.bind(
+                self.getTokens.estimateGasAsync.bind<PolyTokenFaucetContract, any, Promise<number>>(
                     self,
                     _amount,
                     _recipient
@@ -268,7 +268,7 @@ export class PolyTokenFaucetContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transfer.estimateGasAsync.bind(
+                self.transfer.estimateGasAsync.bind<PolyTokenFaucetContract, any, Promise<number>>(
                     self,
                     _to,
                     _value
@@ -389,7 +389,7 @@ export class PolyTokenFaucetContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
+                self.transferFrom.estimateGasAsync.bind<PolyTokenFaucetContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -554,7 +554,7 @@ export class PolyTokenFaucetContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
+                self.approve.estimateGasAsync.bind<PolyTokenFaucetContract, any, Promise<number>>(
                     self,
                     _spender,
                     _value
@@ -740,7 +740,7 @@ export class PolyTokenFaucetContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.increaseApproval.estimateGasAsync.bind(
+                self.increaseApproval.estimateGasAsync.bind<PolyTokenFaucetContract, any, Promise<number>>(
                     self,
                     _spender,
                     _addedValue
@@ -856,7 +856,7 @@ export class PolyTokenFaucetContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.decreaseApproval.estimateGasAsync.bind(
+                self.decreaseApproval.estimateGasAsync.bind<PolyTokenFaucetContract, any, Promise<number>>(
                     self,
                     _spender,
                     _subtractedValue

--- a/src/generated-wrappers/polymath_registry.ts
+++ b/src/generated-wrappers/polymath_registry.ts
@@ -92,7 +92,7 @@ export class PolymathRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.renounceOwnership.estimateGasAsync.bind(
+                self.renounceOwnership.estimateGasAsync.bind<PolymathRegistryContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -175,7 +175,7 @@ export class PolymathRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.reclaimERC20.estimateGasAsync.bind(
+                self.reclaimERC20.estimateGasAsync.bind<PolymathRegistryContract, any, Promise<number>>(
                     self,
                     _tokenContract
                 ),
@@ -302,7 +302,7 @@ export class PolymathRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
+                self.transferOwnership.estimateGasAsync.bind<PolymathRegistryContract, any, Promise<number>>(
                     self,
                     _newOwner
                 ),
@@ -439,7 +439,7 @@ export class PolymathRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeAddress.estimateGasAsync.bind(
+                self.changeAddress.estimateGasAsync.bind<PolymathRegistryContract, any, Promise<number>>(
                     self,
                     _nameKey,
                     _newAddress

--- a/src/generated-wrappers/security_token.ts
+++ b/src/generated-wrappers/security_token.ts
@@ -232,7 +232,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
+                self.approve.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _spender,
                     _value
@@ -468,7 +468,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.decreaseApproval.estimateGasAsync.bind(
+                self.decreaseApproval.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _spender,
                     _subtractedValue
@@ -639,7 +639,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.renounceOwnership.estimateGasAsync.bind(
+                self.renounceOwnership.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -997,7 +997,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.increaseApproval.estimateGasAsync.bind(
+                self.increaseApproval.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _spender,
                     _addedValue
@@ -1178,7 +1178,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
+                self.transferOwnership.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _newOwner
                 ),
@@ -1270,7 +1270,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.updateFromRegistry.estimateGasAsync.bind(
+                self.updateFromRegistry.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -1398,7 +1398,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.addModule.estimateGasAsync.bind(
+                self.addModule.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _moduleFactory,
                     _data,
@@ -1537,7 +1537,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.archiveModule.estimateGasAsync.bind(
+                self.archiveModule.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _module
                 ),
@@ -1634,7 +1634,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.unarchiveModule.estimateGasAsync.bind(
+                self.unarchiveModule.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _module
                 ),
@@ -1731,7 +1731,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.removeModule.estimateGasAsync.bind(
+                self.removeModule.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _module
                 ),
@@ -1938,7 +1938,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.withdrawERC20.estimateGasAsync.bind(
+                self.withdrawERC20.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _tokenContract,
                     _value
@@ -2059,7 +2059,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeModuleBudget.estimateGasAsync.bind(
+                self.changeModuleBudget.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _module,
                     _change,
@@ -2184,7 +2184,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.updateTokenDetails.estimateGasAsync.bind(
+                self.updateTokenDetails.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _newTokenDetails
                 ),
@@ -2281,7 +2281,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeGranularity.estimateGasAsync.bind(
+                self.changeGranularity.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _granularity
                 ),
@@ -2508,7 +2508,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.freezeTransfers.estimateGasAsync.bind(
+                self.freezeTransfers.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -2586,7 +2586,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.unfreezeTransfers.estimateGasAsync.bind(
+                self.unfreezeTransfers.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -2674,7 +2674,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transfer.estimateGasAsync.bind(
+                self.transfer.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _to,
                     _value
@@ -2795,7 +2795,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferWithData.estimateGasAsync.bind(
+                self.transferWithData.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _to,
                     _value,
@@ -2930,7 +2930,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
+                self.transferFrom.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -3070,7 +3070,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferFromWithData.estimateGasAsync.bind(
+                self.transferFromWithData.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -3224,7 +3224,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.verifyTransfer.estimateGasAsync.bind(
+                self.verifyTransfer.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -3358,7 +3358,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.freezeMinting.estimateGasAsync.bind(
+                self.freezeMinting.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -3446,7 +3446,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.mint.estimateGasAsync.bind(
+                self.mint.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _investor,
                     _value
@@ -3567,7 +3567,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.mintWithData.estimateGasAsync.bind(
+                self.mintWithData.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _investor,
                     _value,
@@ -3697,7 +3697,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.mintMulti.estimateGasAsync.bind(
+                self.mintMulti.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _investors,
                     _values
@@ -3858,7 +3858,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.burnWithData.estimateGasAsync.bind(
+                self.burnWithData.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _value,
                     _data
@@ -3979,7 +3979,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.burnFromWithData.estimateGasAsync.bind(
+                self.burnFromWithData.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _from,
                     _value,
@@ -4099,7 +4099,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.createCheckpoint.estimateGasAsync.bind(
+                self.createCheckpoint.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -4287,7 +4287,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.setController.estimateGasAsync.bind(
+                self.setController.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _controller
                 ),
@@ -4379,7 +4379,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.disableController.estimateGasAsync.bind(
+                self.disableController.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -4482,7 +4482,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.forceTransfer.estimateGasAsync.bind(
+                self.forceTransfer.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _from,
                     _to,
@@ -4650,7 +4650,7 @@ export class SecurityTokenContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.forceBurn.estimateGasAsync.bind(
+                self.forceBurn.estimateGasAsync.bind<SecurityTokenContract, any, Promise<number>>(
                     self,
                     _from,
                     _value,

--- a/src/generated-wrappers/security_token_registry.ts
+++ b/src/generated-wrappers/security_token_registry.ts
@@ -357,7 +357,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.initialize.estimateGasAsync.bind(
+                self.initialize.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _polymathRegistry,
                     _STFactory,
@@ -534,7 +534,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.registerTicker.estimateGasAsync.bind(
+                self.registerTicker.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _owner,
                     _ticker,
@@ -684,7 +684,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.modifyTicker.estimateGasAsync.bind(
+                self.modifyTicker.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _owner,
                     _ticker,
@@ -851,7 +851,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.removeTicker.estimateGasAsync.bind(
+                self.removeTicker.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _ticker
                 ),
@@ -953,7 +953,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferTickerOwnership.estimateGasAsync.bind(
+                self.transferTickerOwnership.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _newOwner,
                     _ticker
@@ -1064,7 +1064,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeExpiryLimit.estimateGasAsync.bind(
+                self.changeExpiryLimit.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _newExpiry
                 ),
@@ -1281,7 +1281,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.generateSecurityToken.estimateGasAsync.bind(
+                self.generateSecurityToken.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _name,
                     _ticker,
@@ -1445,7 +1445,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.modifySecurityToken.estimateGasAsync.bind(
+                self.modifySecurityToken.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _name,
                     _ticker,
@@ -1717,7 +1717,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
+                self.transferOwnership.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _newOwner
                 ),
@@ -1809,7 +1809,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pause.estimateGasAsync.bind(
+                self.pause.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -1887,7 +1887,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.unpause.estimateGasAsync.bind(
+                self.unpause.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -1970,7 +1970,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeTickerRegistrationFee.estimateGasAsync.bind(
+                self.changeTickerRegistrationFee.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _tickerRegFee
                 ),
@@ -2067,7 +2067,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeSecurityLaunchFee.estimateGasAsync.bind(
+                self.changeSecurityLaunchFee.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _stLaunchFee
                 ),
@@ -2164,7 +2164,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.reclaimERC20.estimateGasAsync.bind(
+                self.reclaimERC20.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _tokenContract
                 ),
@@ -2276,7 +2276,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.setProtocolVersion.estimateGasAsync.bind(
+                self.setProtocolVersion.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _STFactoryAddress,
                     _major,
@@ -2475,7 +2475,7 @@ export class SecurityTokenRegistryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.updatePolyTokenAddress.estimateGasAsync.bind(
+                self.updatePolyTokenAddress.estimateGasAsync.bind<SecurityTokenRegistryContract, any, Promise<number>>(
                     self,
                     _newAddress
                 ),

--- a/src/generated-wrappers/u_s_d_tiered_s_t_o.ts
+++ b/src/generated-wrappers/u_s_d_tiered_s_t_o.ts
@@ -232,7 +232,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.unpause.estimateGasAsync.bind(
+                self.unpause.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -405,7 +405,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.takeFee.estimateGasAsync.bind(
+                self.takeFee.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _amount
                 ),
@@ -652,7 +652,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.pause.estimateGasAsync.bind(
+                self.pause.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -775,7 +775,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.reclaimERC20.estimateGasAsync.bind(
+                self.reclaimERC20.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _tokenContract
                 ),
@@ -1492,7 +1492,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.configure.estimateGasAsync.bind(
+                self.configure.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _startTime,
                     _endTime,
@@ -1743,7 +1743,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.modifyFunding.estimateGasAsync.bind(
+                self.modifyFunding.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _fundRaiseTypes
                 ),
@@ -1845,7 +1845,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.modifyLimits.estimateGasAsync.bind(
+                self.modifyLimits.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _nonAccreditedLimitUSD,
                     _minimumInvestmentUSD
@@ -1971,7 +1971,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.modifyTiers.estimateGasAsync.bind(
+                self.modifyTiers.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _ratePerTier,
                     _ratePerTierDiscountPoly,
@@ -2115,7 +2115,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.modifyTimes.estimateGasAsync.bind(
+                self.modifyTimes.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _startTime,
                     _endTime
@@ -2236,7 +2236,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.modifyAddresses.estimateGasAsync.bind(
+                self.modifyAddresses.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _wallet,
                     _reserveWallet,
@@ -2356,7 +2356,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.finalize.estimateGasAsync.bind(
+                self.finalize.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -2444,7 +2444,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeAccredited.estimateGasAsync.bind(
+                self.changeAccredited.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _investors,
                     _accredited
@@ -2560,7 +2560,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeNonAccreditedLimit.estimateGasAsync.bind(
+                self.changeNonAccreditedLimit.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _investors,
                     _nonAccreditedLimit
@@ -2671,7 +2671,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeAllowBeneficialInvestments.estimateGasAsync.bind(
+                self.changeAllowBeneficialInvestments.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _allowBeneficialInvestments
                 ),
@@ -2768,7 +2768,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.buyWithETH.estimateGasAsync.bind(
+                self.buyWithETH.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _beneficiary
                 ),
@@ -2870,7 +2870,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.buyWithPOLY.estimateGasAsync.bind(
+                self.buyWithPOLY.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _beneficiary,
                     _investedPOLY
@@ -2986,7 +2986,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.buyWithUSD.estimateGasAsync.bind(
+                self.buyWithUSD.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _beneficiary,
                     _investedDAI
@@ -3102,7 +3102,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.buyWithETHRateLimited.estimateGasAsync.bind(
+                self.buyWithETHRateLimited.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _beneficiary,
                     _minTokens
@@ -3223,7 +3223,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.buyWithPOLYRateLimited.estimateGasAsync.bind(
+                self.buyWithPOLYRateLimited.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _beneficiary,
                     _investedPOLY,
@@ -3358,7 +3358,7 @@ export class USDTieredSTOContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.buyWithUSDRateLimited.estimateGasAsync.bind(
+                self.buyWithUSDRateLimited.estimateGasAsync.bind<USDTieredSTOContract, any, Promise<number>>(
                     self,
                     _beneficiary,
                     _investedDAI,

--- a/src/generated-wrappers/u_s_d_tiered_s_t_o_factory.ts
+++ b/src/generated-wrappers/u_s_d_tiered_s_t_o_factory.ts
@@ -28,6 +28,7 @@ export enum USDTieredSTOFactoryEvents {
     ChangeSTVersionBound = 'ChangeSTVersionBound',
     OwnershipRenounced = 'OwnershipRenounced',
     OwnershipTransferred = 'OwnershipTransferred',
+    GenerateModuleFromFactory = 'GenerateModuleFromFactory',
 }
 
 export interface USDTieredSTOFactoryChangeFactorySetupFeeEventArgs extends DecodedLogArgs {
@@ -197,7 +198,7 @@ export class USDTieredSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeTitle.estimateGasAsync.bind(
+                self.changeTitle.estimateGasAsync.bind<USDTieredSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newTitle
                 ),
@@ -294,7 +295,7 @@ export class USDTieredSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeFactorySubscriptionFee.estimateGasAsync.bind(
+                self.changeFactorySubscriptionFee.estimateGasAsync.bind<USDTieredSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newSubscriptionCost
                 ),
@@ -451,7 +452,7 @@ export class USDTieredSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeFactorySetupFee.estimateGasAsync.bind(
+                self.changeFactorySetupFee.estimateGasAsync.bind<USDTieredSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newSetupCost
                 ),
@@ -548,7 +549,7 @@ export class USDTieredSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeVersion.estimateGasAsync.bind(
+                self.changeVersion.estimateGasAsync.bind<USDTieredSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newVersion
                 ),
@@ -670,7 +671,7 @@ export class USDTieredSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.renounceOwnership.estimateGasAsync.bind(
+                self.renounceOwnership.estimateGasAsync.bind<USDTieredSTOFactoryContract, any, Promise<number>>(
                     self,
                 ),
             );
@@ -843,7 +844,7 @@ export class USDTieredSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeName.estimateGasAsync.bind(
+                self.changeName.estimateGasAsync.bind<USDTieredSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newName
                 ),
@@ -1000,7 +1001,7 @@ export class USDTieredSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeFactoryUsageFee.estimateGasAsync.bind(
+                self.changeFactoryUsageFee.estimateGasAsync.bind<USDTieredSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newUsageCost
                 ),
@@ -1157,7 +1158,7 @@ export class USDTieredSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeDescription.estimateGasAsync.bind(
+                self.changeDescription.estimateGasAsync.bind<USDTieredSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newDesc
                 ),
@@ -1254,7 +1255,7 @@ export class USDTieredSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
+                self.transferOwnership.estimateGasAsync.bind<USDTieredSTOFactoryContract, any, Promise<number>>(
                     self,
                     _newOwner
                 ),
@@ -1386,7 +1387,7 @@ export class USDTieredSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.changeSTVersionBounds.estimateGasAsync.bind(
+                self.changeSTVersionBounds.estimateGasAsync.bind<USDTieredSTOFactoryContract, any, Promise<number>>(
                     self,
                     _boundType,
                     _newVersion
@@ -1497,7 +1498,7 @@ export class USDTieredSTOFactoryContract extends BaseContract {
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
-                self.deploy.estimateGasAsync.bind(
+                self.deploy.estimateGasAsync.bind<USDTieredSTOFactoryContract, any, Promise<number>>(
                     self,
                     _data
                 ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@0x/abi-gen@^1.0.19":
+"@0x/abi-gen@1.0.19":
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/@0x/abi-gen/-/abi-gen-1.0.19.tgz#4c40ee73f544803ef8254328041333f2fa180b16"
   integrity sha512-J/f0e4wn0yOArnObUqm3Q7q9DUk3TE2nouWB9alDaVq2bFXgf5UWyUxdd4n+REiSluD4+EszUSAE8zVuPyLGYQ==
@@ -87,7 +87,7 @@
     "@0x/typescript-typings" "^3.0.6"
     lodash "^4.17.5"
 
-"@0x/types@^1.4.1":
+"@0x/types@1.4.1", "@0x/types@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@0x/types/-/types-1.4.1.tgz#0468c1f04b7689498b0729787e1218da8d1e1b9f"
   integrity sha512-nz58oN5v83Ui2mag1NN+GAmpp5yNRhJC25eyDnYjXez0QqU/hOcgC8F0R0IGj/WQbs/d9rWV+iUy7GAhmkmOcw==
@@ -151,7 +151,7 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.119.tgz#be847e5f4bc3e35e46d041c394ead8b603ad8b39"
   integrity sha512-Z3TNyBL8Vd/M9D9Ms2S3LmFq2sSMzahodD6rCS9V2N44HUMINb75jNkSuwAx7eo2ufqTdfOdtGQpNbieUjPQmw==
 
-"@types/node@*", "@types/node@^10.3.2":
+"@types/node@*", "@types/node@^10.12.18", "@types/node@^10.3.2":
   version "10.12.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
@@ -2159,6 +2159,11 @@ type-is@~1.6.16:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.18"
+
+typescript@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.1.tgz#0b7a04b8cf3868188de914d9568bd030f0c56192"
+  integrity sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
This PR fixes a typing error caused when bind is called on a function which receives more than 4 arguments with different types