### PR TITLE
feat(usdtieredsto): tiered sto allows set any stablecoin we want

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@commitlint/config-conventional": "^8.2.0",
     "@polymathnetwork/contract-artifacts": "3.0.0",
     "@polymathnetwork/contract-artifacts-3-0-0": "npm:@polymathnetwork/contract-artifacts@3.0.0",
-    "@polymathnetwork/contract-artifacts-3-1-0": "npm:@polymathnetwork/contract-artifacts@3.1.0-beta.2",
+    "@polymathnetwork/contract-artifacts-3-1-0": "npm:@polymathnetwork/contract-artifacts@3.1.0-beta.3",
     "@semantic-release/changelog": "^3.0.4",
     "@semantic-release/git": "^7.1.0-beta.3",
     "@types/lodash": "^4.14.136",

--- a/scripts/generate_version.sh
+++ b/scripts/generate_version.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 version=$1
-./node_modules/@0x/abi-gen/bin/abi-gen.js --abis "node_modules/@polymathnetwork/contract-artifacts-${version//./-}/artifacts/@(*).json" --template contract.handlebars --partials 'partials/**/*.handlebars' --output "src/generated-wrappers/$version/"
+./node_modules/@0x/abi-gen/bin/abi-gen.js --abis "node_modules/@polymathnetwork/contract-artifacts-${version//./-}/lib/artifacts/@(*).json" --template contract.handlebars --partials 'partials/**/*.handlebars' --output "src/generated-wrappers/$version/"

--- a/src/generated-wrappers/3.1.0/u_s_d_tiered_s_t_o.ts
+++ b/src/generated-wrappers/3.1.0/u_s_d_tiered_s_t_o.ts
@@ -32,6 +32,8 @@ export type USDTieredSTOEventArgs_3_1_0 =
   | USDTieredSTOSetTimesEventArgs_3_1_0
   | USDTieredSTOSetTiersEventArgs_3_1_0
   | USDTieredSTOSetTreasuryWalletEventArgs_3_1_0
+  | USDTieredSTOSetOraclesEventArgs_3_1_0
+  | USDTieredSTOUsageFeeDeductedEventArgs_3_1_0
   | USDTieredSTOPauseEventArgs_3_1_0
   | USDTieredSTOUnpauseEventArgs_3_1_0
   | USDTieredSTOSetFundRaiseTypesEventArgs_3_1_0
@@ -50,6 +52,8 @@ export enum USDTieredSTOEvents_3_1_0 {
   SetTimes = 'SetTimes',
   SetTiers = 'SetTiers',
   SetTreasuryWallet = 'SetTreasuryWallet',
+  SetOracles = 'SetOracles',
+  UsageFeeDeducted = 'UsageFeeDeducted',
   Pause = 'Pause',
   Unpause = 'Unpause',
   SetFundRaiseTypes = 'SetFundRaiseTypes',
@@ -94,7 +98,7 @@ export interface USDTieredSTOReserveTokenTransferEventArgs_3_1_0 extends Decoded
 }
 export interface USDTieredSTOSetAddressesEventArgs_3_1_0 extends DecodedLogArgs {
   _wallet: string;
-  _usdTokens: string[];
+  _stableTokens: string[];
 }
 export interface USDTieredSTOSetLimitsEventArgs_3_1_0 extends DecodedLogArgs {
   _nonAccreditedLimitUSD: BigNumber;
@@ -113,6 +117,15 @@ export interface USDTieredSTOSetTiersEventArgs_3_1_0 extends DecodedLogArgs {
 export interface USDTieredSTOSetTreasuryWalletEventArgs_3_1_0 extends DecodedLogArgs {
   _oldWallet: string;
   _newWallet: string;
+}
+export interface USDTieredSTOSetOraclesEventArgs_3_1_0 extends DecodedLogArgs {
+  _denominatedCurrency: string;
+  _isCustomOracles: boolean;
+}
+export interface USDTieredSTOUsageFeeDeductedEventArgs_3_1_0 extends DecodedLogArgs {
+  _wallet: string;
+  _securityToken: string;
+  _module: string;
 }
 export interface USDTieredSTOPauseEventArgs_3_1_0 extends DecodedLogArgs {
   account: string;
@@ -279,6 +292,44 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
     getABIEncodedTransactionData(): string {
       const self = (this as any) as USDTieredSTOContract_3_1_0;
       const abiEncodedTransactionData = self._strictEncodeArguments('reclaimETH()', []);
+      return abiEncodedTransactionData;
+    },
+  };
+  public denominatedCurrency = {
+    async callAsync(callData: Partial<CallData> = {}, defaultBlock?: BlockParam): Promise<string> {
+      assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+        schemas.addressSchema,
+        schemas.numberSchema,
+        schemas.jsNumber,
+      ]);
+      if (defaultBlock !== undefined) {
+        assert.isBlockParam('defaultBlock', defaultBlock);
+      }
+      const self = (this as any) as USDTieredSTOContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('denominatedCurrency()', []);
+      const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...callData,
+          data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+      );
+      callDataWithDefaults.from = callDataWithDefaults.from
+        ? callDataWithDefaults.from.toLowerCase()
+        : callDataWithDefaults.from;
+
+      const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
+      BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
+      const abiEncoder = self._lookupAbiEncoder('denominatedCurrency()');
+      // tslint:disable boolean-naming
+      const result = abiEncoder.strictDecodeReturnValue<string>(rawCallResult);
+      // tslint:enable boolean-naming
+      return result;
+    },
+    getABIEncodedTransactionData(): string {
+      const self = (this as any) as USDTieredSTOContract_3_1_0;
+      const abiEncodedTransactionData = self._strictEncodeArguments('denominatedCurrency()', []);
       return abiEncodedTransactionData;
     },
   };
@@ -1739,7 +1790,9 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       _fundRaiseTypes: Array<number | BigNumber>,
       _wallet: string,
       _treasuryWallet: string,
-      _usdTokens: string[],
+      _stableTokens: string[],
+      _customOracleAddresses: string[],
+      _denominatedCurrency: string,
       txData?: Partial<TxData> | undefined,
       estimateGasFactor?: number,
     ): Promise<PolyResponse> {
@@ -1754,10 +1807,12 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       assert.isArray('_fundRaiseTypes', _fundRaiseTypes);
       assert.isString('_wallet', _wallet);
       assert.isString('_treasuryWallet', _treasuryWallet);
-      assert.isArray('_usdTokens', _usdTokens);
+      assert.isArray('_stableTokens', _stableTokens);
+      assert.isArray('_customOracleAddresses', _customOracleAddresses);
+      assert.isString('_denominatedCurrency', _denominatedCurrency);
       const self = (this as any) as USDTieredSTOContract_3_1_0;
       const encodedData = self._strictEncodeArguments(
-        'configure(uint256,uint256,uint256[],uint256[],uint256[],uint256[],uint256,uint256,uint8[],address,address,address[])',
+        'configure(uint256,uint256,uint256[],uint256[],uint256[],uint256[],uint256,uint256,uint8[],address,address,address[],address[],bytes32)',
         [
           _startTime,
           _endTime,
@@ -1770,7 +1825,9 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
           _fundRaiseTypes,
           _wallet,
           _treasuryWallet,
-          _usdTokens,
+          _stableTokens,
+          _customOracleAddresses,
+          _denominatedCurrency,
         ],
       );
       const contractDefaults = self._web3Wrapper.getContractDefaults();
@@ -1798,7 +1855,9 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
           _fundRaiseTypes,
           _wallet,
           _treasuryWallet,
-          _usdTokens,
+          _stableTokens,
+          _customOracleAddresses,
+          _denominatedCurrency,
           estimateGasFactor,
         ),
       );
@@ -1823,7 +1882,9 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       _fundRaiseTypes: Array<number | BigNumber>,
       _wallet: string,
       _treasuryWallet: string,
-      _usdTokens: string[],
+      _stableTokens: string[],
+      _customOracleAddresses: string[],
+      _denominatedCurrency: string,
       factor?: number,
       txData?: Partial<TxData> | undefined,
     ): Promise<number> {
@@ -1838,10 +1899,12 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       assert.isArray('_fundRaiseTypes', _fundRaiseTypes);
       assert.isString('_wallet', _wallet);
       assert.isString('_treasuryWallet', _treasuryWallet);
-      assert.isArray('_usdTokens', _usdTokens);
+      assert.isArray('_stableTokens', _stableTokens);
+      assert.isArray('_customOracleAddresses', _customOracleAddresses);
+      assert.isString('_denominatedCurrency', _denominatedCurrency);
       const self = (this as any) as USDTieredSTOContract_3_1_0;
       const encodedData = self._strictEncodeArguments(
-        'configure(uint256,uint256,uint256[],uint256[],uint256[],uint256[],uint256,uint256,uint8[],address,address,address[])',
+        'configure(uint256,uint256,uint256[],uint256[],uint256[],uint256[],uint256,uint256,uint8[],address,address,address[],address[],bytes32)',
         [
           _startTime,
           _endTime,
@@ -1854,7 +1917,9 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
           _fundRaiseTypes,
           _wallet,
           _treasuryWallet,
-          _usdTokens,
+          _stableTokens,
+          _customOracleAddresses,
+          _denominatedCurrency,
         ],
       );
       const contractDefaults = self._web3Wrapper.getContractDefaults();
@@ -1892,7 +1957,9 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       _fundRaiseTypes: Array<number | BigNumber>,
       _wallet: string,
       _treasuryWallet: string,
-      _usdTokens: string[],
+      _stableTokens: string[],
+      _customOracleAddresses: string[],
+      _denominatedCurrency: string,
       callData: Partial<CallData> = {},
       defaultBlock?: BlockParam,
     ): Promise<void> {
@@ -1907,7 +1974,9 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       assert.isArray('_fundRaiseTypes', _fundRaiseTypes);
       assert.isString('_wallet', _wallet);
       assert.isString('_treasuryWallet', _treasuryWallet);
-      assert.isArray('_usdTokens', _usdTokens);
+      assert.isArray('_stableTokens', _stableTokens);
+      assert.isArray('_customOracleAddresses', _customOracleAddresses);
+      assert.isString('_denominatedCurrency', _denominatedCurrency);
       assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
         schemas.addressSchema,
         schemas.numberSchema,
@@ -1918,7 +1987,7 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       }
       const self = (this as any) as USDTieredSTOContract_3_1_0;
       const encodedData = self._strictEncodeArguments(
-        'configure(uint256,uint256,uint256[],uint256[],uint256[],uint256[],uint256,uint256,uint8[],address,address,address[])',
+        'configure(uint256,uint256,uint256[],uint256[],uint256[],uint256[],uint256,uint256,uint8[],address,address,address[],address[],bytes32)',
         [
           _startTime,
           _endTime,
@@ -1931,7 +2000,9 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
           _fundRaiseTypes,
           _wallet,
           _treasuryWallet,
-          _usdTokens,
+          _stableTokens,
+          _customOracleAddresses,
+          _denominatedCurrency,
         ],
       );
       const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -1949,7 +2020,7 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
       BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
       const abiEncoder = self._lookupAbiEncoder(
-        'configure(uint256,uint256,uint256[],uint256[],uint256[],uint256[],uint256,uint256,uint8[],address,address,address[])',
+        'configure(uint256,uint256,uint256[],uint256[],uint256[],uint256[],uint256,uint256,uint8[],address,address,address[],address[],bytes32)',
       );
       // tslint:disable boolean-naming
       const result = abiEncoder.strictDecodeReturnValue<void>(rawCallResult);
@@ -1968,7 +2039,9 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       _fundRaiseTypes: Array<number | BigNumber>,
       _wallet: string,
       _treasuryWallet: string,
-      _usdTokens: string[],
+      _stableTokens: string[],
+      _customOracleAddresses: string[],
+      _denominatedCurrency: string,
     ): string {
       assert.isBigNumber('_startTime', _startTime);
       assert.isBigNumber('_endTime', _endTime);
@@ -1981,10 +2054,12 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       assert.isArray('_fundRaiseTypes', _fundRaiseTypes);
       assert.isString('_wallet', _wallet);
       assert.isString('_treasuryWallet', _treasuryWallet);
-      assert.isArray('_usdTokens', _usdTokens);
+      assert.isArray('_stableTokens', _stableTokens);
+      assert.isArray('_customOracleAddresses', _customOracleAddresses);
+      assert.isString('_denominatedCurrency', _denominatedCurrency);
       const self = (this as any) as USDTieredSTOContract_3_1_0;
       const abiEncodedTransactionData = self._strictEncodeArguments(
-        'configure(uint256,uint256,uint256[],uint256[],uint256[],uint256[],uint256,uint256,uint8[],address,address,address[])',
+        'configure(uint256,uint256,uint256[],uint256[],uint256[],uint256[],uint256,uint256,uint8[],address,address,address[],address[],bytes32)',
         [
           _startTime,
           _endTime,
@@ -1997,7 +2072,9 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
           _fundRaiseTypes,
           _wallet,
           _treasuryWallet,
-          _usdTokens,
+          _stableTokens,
+          _customOracleAddresses,
+          _denominatedCurrency,
         ],
       );
       return abiEncodedTransactionData;
@@ -2719,18 +2796,18 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
     async sendTransactionAsync(
       _wallet: string,
       _treasuryWallet: string,
-      _usdTokens: string[],
+      _stableTokens: string[],
       txData?: Partial<TxData> | undefined,
       estimateGasFactor?: number,
     ): Promise<PolyResponse> {
       assert.isString('_wallet', _wallet);
       assert.isString('_treasuryWallet', _treasuryWallet);
-      assert.isArray('_usdTokens', _usdTokens);
+      assert.isArray('_stableTokens', _stableTokens);
       const self = (this as any) as USDTieredSTOContract_3_1_0;
       const encodedData = self._strictEncodeArguments('modifyAddresses(address,address,address[])', [
         _wallet,
         _treasuryWallet,
-        _usdTokens,
+        _stableTokens,
       ]);
       const contractDefaults = self._web3Wrapper.getContractDefaults();
       const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
@@ -2748,7 +2825,7 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
           self,
           _wallet,
           _treasuryWallet,
-          _usdTokens,
+          _stableTokens,
           estimateGasFactor,
         ),
       );
@@ -2764,18 +2841,18 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
     async estimateGasAsync(
       _wallet: string,
       _treasuryWallet: string,
-      _usdTokens: string[],
+      _stableTokens: string[],
       factor?: number,
       txData?: Partial<TxData> | undefined,
     ): Promise<number> {
       assert.isString('_wallet', _wallet);
       assert.isString('_treasuryWallet', _treasuryWallet);
-      assert.isArray('_usdTokens', _usdTokens);
+      assert.isArray('_stableTokens', _stableTokens);
       const self = (this as any) as USDTieredSTOContract_3_1_0;
       const encodedData = self._strictEncodeArguments('modifyAddresses(address,address,address[])', [
         _wallet,
         _treasuryWallet,
-        _usdTokens,
+        _stableTokens,
       ]);
       const contractDefaults = self._web3Wrapper.getContractDefaults();
       const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
@@ -2803,13 +2880,13 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
     async callAsync(
       _wallet: string,
       _treasuryWallet: string,
-      _usdTokens: string[],
+      _stableTokens: string[],
       callData: Partial<CallData> = {},
       defaultBlock?: BlockParam,
     ): Promise<void> {
       assert.isString('_wallet', _wallet);
       assert.isString('_treasuryWallet', _treasuryWallet);
-      assert.isArray('_usdTokens', _usdTokens);
+      assert.isArray('_stableTokens', _stableTokens);
       assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
         schemas.addressSchema,
         schemas.numberSchema,
@@ -2822,7 +2899,7 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       const encodedData = self._strictEncodeArguments('modifyAddresses(address,address,address[])', [
         _wallet,
         _treasuryWallet,
-        _usdTokens,
+        _stableTokens,
       ]);
       const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
         {
@@ -2844,30 +2921,33 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       // tslint:enable boolean-naming
       return result;
     },
-    getABIEncodedTransactionData(_wallet: string, _treasuryWallet: string, _usdTokens: string[]): string {
+    getABIEncodedTransactionData(_wallet: string, _treasuryWallet: string, _stableTokens: string[]): string {
       assert.isString('_wallet', _wallet);
       assert.isString('_treasuryWallet', _treasuryWallet);
-      assert.isArray('_usdTokens', _usdTokens);
+      assert.isArray('_stableTokens', _stableTokens);
       const self = (this as any) as USDTieredSTOContract_3_1_0;
       const abiEncodedTransactionData = self._strictEncodeArguments('modifyAddresses(address,address,address[])', [
         _wallet,
         _treasuryWallet,
-        _usdTokens,
+        _stableTokens,
       ]);
       return abiEncodedTransactionData;
     },
   };
-  public modifyOracle = {
+  public modifyOracles = {
     async sendTransactionAsync(
-      _fundRaiseType: number | BigNumber,
-      _oracleAddress: string,
+      _customOracleAddresses: string[],
+      _denominatedCurrencySymbol: string,
       txData?: Partial<TxData> | undefined,
       estimateGasFactor?: number,
     ): Promise<PolyResponse> {
-      assert.isNumberOrBigNumber('_fundRaiseType', _fundRaiseType);
-      assert.isString('_oracleAddress', _oracleAddress);
+      assert.isArray('_customOracleAddresses', _customOracleAddresses);
+      assert.isString('_denominatedCurrencySymbol', _denominatedCurrencySymbol);
       const self = (this as any) as USDTieredSTOContract_3_1_0;
-      const encodedData = self._strictEncodeArguments('modifyOracle(uint8,address)', [_fundRaiseType, _oracleAddress]);
+      const encodedData = self._strictEncodeArguments('modifyOracles(address[],bytes32)', [
+        _customOracleAddresses,
+        _denominatedCurrencySymbol,
+      ]);
       const contractDefaults = self._web3Wrapper.getContractDefaults();
       const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
       const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -2880,10 +2960,10 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
           from: defaultFromAddress,
           ...contractDefaults,
         },
-        self.modifyOracle.estimateGasAsync.bind<USDTieredSTOContract_3_1_0, any, Promise<number>>(
+        self.modifyOracles.estimateGasAsync.bind<USDTieredSTOContract_3_1_0, any, Promise<number>>(
           self,
-          _fundRaiseType,
-          _oracleAddress,
+          _customOracleAddresses,
+          _denominatedCurrencySymbol,
           estimateGasFactor,
         ),
       );
@@ -2897,15 +2977,18 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       return new PolyResponse(txHash, receipt);
     },
     async estimateGasAsync(
-      _fundRaiseType: number | BigNumber,
-      _oracleAddress: string,
+      _customOracleAddresses: string[],
+      _denominatedCurrencySymbol: string,
       factor?: number,
       txData?: Partial<TxData> | undefined,
     ): Promise<number> {
-      assert.isNumberOrBigNumber('_fundRaiseType', _fundRaiseType);
-      assert.isString('_oracleAddress', _oracleAddress);
+      assert.isArray('_customOracleAddresses', _customOracleAddresses);
+      assert.isString('_denominatedCurrencySymbol', _denominatedCurrencySymbol);
       const self = (this as any) as USDTieredSTOContract_3_1_0;
-      const encodedData = self._strictEncodeArguments('modifyOracle(uint8,address)', [_fundRaiseType, _oracleAddress]);
+      const encodedData = self._strictEncodeArguments('modifyOracles(address[],bytes32)', [
+        _customOracleAddresses,
+        _denominatedCurrencySymbol,
+      ]);
       const contractDefaults = self._web3Wrapper.getContractDefaults();
       const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
       const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -2930,13 +3013,13 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       return _safetyGasEstimation > networkGasLimit ? networkGasLimit : _safetyGasEstimation;
     },
     async callAsync(
-      _fundRaiseType: number | BigNumber,
-      _oracleAddress: string,
+      _customOracleAddresses: string[],
+      _denominatedCurrencySymbol: string,
       callData: Partial<CallData> = {},
       defaultBlock?: BlockParam,
     ): Promise<void> {
-      assert.isNumberOrBigNumber('_fundRaiseType', _fundRaiseType);
-      assert.isString('_oracleAddress', _oracleAddress);
+      assert.isArray('_customOracleAddresses', _customOracleAddresses);
+      assert.isString('_denominatedCurrencySymbol', _denominatedCurrencySymbol);
       assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
         schemas.addressSchema,
         schemas.numberSchema,
@@ -2946,7 +3029,10 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
         assert.isBlockParam('defaultBlock', defaultBlock);
       }
       const self = (this as any) as USDTieredSTOContract_3_1_0;
-      const encodedData = self._strictEncodeArguments('modifyOracle(uint8,address)', [_fundRaiseType, _oracleAddress]);
+      const encodedData = self._strictEncodeArguments('modifyOracles(address[],bytes32)', [
+        _customOracleAddresses,
+        _denominatedCurrencySymbol,
+      ]);
       const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
         {
           to: self.address,
@@ -2961,19 +3047,19 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
 
       const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
       BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-      const abiEncoder = self._lookupAbiEncoder('modifyOracle(uint8,address)');
+      const abiEncoder = self._lookupAbiEncoder('modifyOracles(address[],bytes32)');
       // tslint:disable boolean-naming
       const result = abiEncoder.strictDecodeReturnValue<void>(rawCallResult);
       // tslint:enable boolean-naming
       return result;
     },
-    getABIEncodedTransactionData(_fundRaiseType: number | BigNumber, _oracleAddress: string): string {
-      assert.isNumberOrBigNumber('_fundRaiseType', _fundRaiseType);
-      assert.isString('_oracleAddress', _oracleAddress);
+    getABIEncodedTransactionData(_customOracleAddresses: string[], _denominatedCurrencySymbol: string): string {
+      assert.isArray('_customOracleAddresses', _customOracleAddresses);
+      assert.isString('_denominatedCurrencySymbol', _denominatedCurrencySymbol);
       const self = (this as any) as USDTieredSTOContract_3_1_0;
-      const abiEncodedTransactionData = self._strictEncodeArguments('modifyOracle(uint8,address)', [
-        _fundRaiseType,
-        _oracleAddress,
+      const abiEncodedTransactionData = self._strictEncodeArguments('modifyOracles(address[],bytes32)', [
+        _customOracleAddresses,
+        _denominatedCurrencySymbol,
       ]);
       return abiEncodedTransactionData;
     },
@@ -4352,6 +4438,50 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       return abiEncodedTransactionData;
     },
   };
+  public getCustomOracleAddress = {
+    async callAsync(
+      _fundRaiseType: number | BigNumber,
+      callData: Partial<CallData> = {},
+      defaultBlock?: BlockParam,
+    ): Promise<string> {
+      assert.isNumberOrBigNumber('_fundRaiseType', _fundRaiseType);
+      assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+        schemas.addressSchema,
+        schemas.numberSchema,
+        schemas.jsNumber,
+      ]);
+      if (defaultBlock !== undefined) {
+        assert.isBlockParam('defaultBlock', defaultBlock);
+      }
+      const self = (this as any) as USDTieredSTOContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('getCustomOracleAddress(uint8)', [_fundRaiseType]);
+      const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...callData,
+          data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+      );
+      callDataWithDefaults.from = callDataWithDefaults.from
+        ? callDataWithDefaults.from.toLowerCase()
+        : callDataWithDefaults.from;
+
+      const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
+      BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
+      const abiEncoder = self._lookupAbiEncoder('getCustomOracleAddress(uint8)');
+      // tslint:disable boolean-naming
+      const result = abiEncoder.strictDecodeReturnValue<string>(rawCallResult);
+      // tslint:enable boolean-naming
+      return result;
+    },
+    getABIEncodedTransactionData(_fundRaiseType: number | BigNumber): string {
+      assert.isNumberOrBigNumber('_fundRaiseType', _fundRaiseType);
+      const self = (this as any) as USDTieredSTOContract_3_1_0;
+      const abiEncodedTransactionData = self._strictEncodeArguments('getCustomOracleAddress(uint8)', [_fundRaiseType]);
+      return abiEncodedTransactionData;
+    },
+  };
   public convertToUSD = {
     async sendTransactionAsync(
       _fundRaiseType: number | BigNumber,
@@ -5090,6 +5220,20 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
       {
         constant: true,
         inputs: [],
+        name: 'denominatedCurrency',
+        outputs: [
+          {
+            name: '',
+            type: 'bytes32',
+          },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        constant: true,
+        inputs: [],
         name: 'ADMIN',
         outputs: [
           {
@@ -5759,7 +5903,7 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
             indexed: true,
           },
           {
-            name: '_usdTokens',
+            name: '_stableTokens',
             type: 'address[]',
             indexed: false,
           },
@@ -5847,6 +5991,47 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
           },
         ],
         name: 'SetTreasuryWallet',
+        outputs: [],
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            name: '_denominatedCurrency',
+            type: 'bytes32',
+            indexed: false,
+          },
+          {
+            name: '_isCustomOracles',
+            type: 'bool',
+            indexed: false,
+          },
+        ],
+        name: 'SetOracles',
+        outputs: [],
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            name: '_wallet',
+            type: 'address',
+            indexed: true,
+          },
+          {
+            name: '_securityToken',
+            type: 'address',
+            indexed: true,
+          },
+          {
+            name: '_module',
+            type: 'address',
+            indexed: false,
+          },
+        ],
+        name: 'UsageFeeDeducted',
         outputs: [],
         type: 'event',
       },
@@ -5983,8 +6168,16 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
             type: 'address',
           },
           {
-            name: '_usdTokens',
+            name: '_stableTokens',
             type: 'address[]',
+          },
+          {
+            name: '_customOracleAddresses',
+            type: 'address[]',
+          },
+          {
+            name: '_denominatedCurrency',
+            type: 'bytes32',
           },
         ],
         name: 'configure',
@@ -6099,7 +6292,7 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
             type: 'address',
           },
           {
-            name: '_usdTokens',
+            name: '_stableTokens',
             type: 'address[]',
           },
         ],
@@ -6113,15 +6306,15 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
         constant: false,
         inputs: [
           {
-            name: '_fundRaiseType',
-            type: 'uint8',
+            name: '_customOracleAddresses',
+            type: 'address[]',
           },
           {
-            name: '_oracleAddress',
-            type: 'address',
+            name: '_denominatedCurrencySymbol',
+            type: 'bytes32',
           },
         ],
-        name: 'modifyOracle',
+        name: 'modifyOracles',
         outputs: [],
         payable: false,
         stateMutability: 'nonpayable',
@@ -6433,6 +6626,25 @@ export class USDTieredSTOContract_3_1_0 extends BaseContract {
         ],
         payable: false,
         stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        constant: true,
+        inputs: [
+          {
+            name: '_fundRaiseType',
+            type: 'uint8',
+          },
+        ],
+        name: 'getCustomOracleAddress',
+        outputs: [
+          {
+            name: '',
+            type: 'address',
+          },
+        ],
+        payable: false,
+        stateMutability: 'view',
         type: 'function',
       },
       {

--- a/src/generated-wrappers/3.1.0/u_s_d_tiered_s_t_o_factory.ts
+++ b/src/generated-wrappers/3.1.0/u_s_d_tiered_s_t_o_factory.ts
@@ -25,7 +25,10 @@ export type USDTieredSTOFactoryEventArgs_3_1_0 =
   | USDTieredSTOFactoryModuleUpgradedEventArgs_3_1_0
   | USDTieredSTOFactoryOwnershipTransferredEventArgs_3_1_0
   | USDTieredSTOFactoryChangeSetupCostEventArgs_3_1_0
+  | USDTieredSTOFactoryChangeUsageCostEventArgs_3_1_0
+  | USDTieredSTOFactoryUsageCostProposedEventArgs_3_1_0
   | USDTieredSTOFactoryChangeCostTypeEventArgs_3_1_0
+  | USDTieredSTOFactoryChangeCostTypeProposedEventArgs_3_1_0
   | USDTieredSTOFactoryGenerateModuleFromFactoryEventArgs_3_1_0
   | USDTieredSTOFactoryChangeSTVersionBoundEventArgs_3_1_0;
 
@@ -34,7 +37,10 @@ export enum USDTieredSTOFactoryEvents_3_1_0 {
   ModuleUpgraded = 'ModuleUpgraded',
   OwnershipTransferred = 'OwnershipTransferred',
   ChangeSetupCost = 'ChangeSetupCost',
+  ChangeUsageCost = 'ChangeUsageCost',
+  UsageCostProposed = 'UsageCostProposed',
   ChangeCostType = 'ChangeCostType',
+  ChangeCostTypeProposed = 'ChangeCostTypeProposed',
   GenerateModuleFromFactory = 'GenerateModuleFromFactory',
   ChangeSTVersionBound = 'ChangeSTVersionBound',
 }
@@ -58,9 +64,21 @@ export interface USDTieredSTOFactoryChangeSetupCostEventArgs_3_1_0 extends Decod
   _oldSetupCost: BigNumber;
   _newSetupCost: BigNumber;
 }
+export interface USDTieredSTOFactoryChangeUsageCostEventArgs_3_1_0 extends DecodedLogArgs {
+  _oldUsageCost: BigNumber;
+  _newUsageCost: BigNumber;
+}
+export interface USDTieredSTOFactoryUsageCostProposedEventArgs_3_1_0 extends DecodedLogArgs {
+  _proposedFee: BigNumber;
+  _currentFee: BigNumber;
+}
 export interface USDTieredSTOFactoryChangeCostTypeEventArgs_3_1_0 extends DecodedLogArgs {
   _isOldCostInPoly: boolean;
   _isNewCostInPoly: boolean;
+}
+export interface USDTieredSTOFactoryChangeCostTypeProposedEventArgs_3_1_0 extends DecodedLogArgs {
+  _proposedCostType: boolean;
+  _currentCostType: boolean;
 }
 export interface USDTieredSTOFactoryGenerateModuleFromFactoryEventArgs_3_1_0 extends DecodedLogArgs {
   _module: string;
@@ -117,6 +135,116 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
     getABIEncodedTransactionData(): string {
       const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
       const abiEncodedTransactionData = self._strictEncodeArguments('name()', []);
+      return abiEncodedTransactionData;
+    },
+  };
+  public proposeUsageCost = {
+    async sendTransactionAsync(
+      _usageCostProposed: BigNumber,
+      txData?: Partial<TxData> | undefined,
+      estimateGasFactor?: number,
+    ): Promise<PolyResponse> {
+      assert.isBigNumber('_usageCostProposed', _usageCostProposed);
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('proposeUsageCost(uint256)', [_usageCostProposed]);
+      const contractDefaults = self._web3Wrapper.getContractDefaults();
+      const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
+      const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...txData,
+          data: encodedData,
+        },
+        {
+          from: defaultFromAddress,
+          ...contractDefaults,
+        },
+        self.proposeUsageCost.estimateGasAsync.bind<USDTieredSTOFactoryContract_3_1_0, any, Promise<number>>(
+          self,
+          _usageCostProposed,
+          estimateGasFactor,
+        ),
+      );
+      if (txDataWithDefaults.from !== undefined) {
+        txDataWithDefaults.from = txDataWithDefaults.from.toLowerCase();
+      }
+
+      const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+      const receipt = self._web3Wrapper.awaitTransactionSuccessAsync(txHash);
+
+      return new PolyResponse(txHash, receipt);
+    },
+    async estimateGasAsync(
+      _usageCostProposed: BigNumber,
+      factor?: number,
+      txData?: Partial<TxData> | undefined,
+    ): Promise<number> {
+      assert.isBigNumber('_usageCostProposed', _usageCostProposed);
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('proposeUsageCost(uint256)', [_usageCostProposed]);
+      const contractDefaults = self._web3Wrapper.getContractDefaults();
+      const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
+      const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...txData,
+          data: encodedData,
+        },
+        {
+          from: defaultFromAddress,
+          ...contractDefaults,
+        },
+      );
+      if (txDataWithDefaults.from !== undefined) {
+        txDataWithDefaults.from = txDataWithDefaults.from.toLowerCase();
+      }
+
+      const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+      const networkGasLimit = (await self._web3Wrapper.getBlockWithTransactionDataAsync('latest')).gasLimit;
+      const _factor = factor === undefined ? self._defaultEstimateGasFactor : factor;
+      const _safetyGasEstimation = Math.round(_factor * gas);
+      return _safetyGasEstimation > networkGasLimit ? networkGasLimit : _safetyGasEstimation;
+    },
+    async callAsync(
+      _usageCostProposed: BigNumber,
+      callData: Partial<CallData> = {},
+      defaultBlock?: BlockParam,
+    ): Promise<void> {
+      assert.isBigNumber('_usageCostProposed', _usageCostProposed);
+      assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+        schemas.addressSchema,
+        schemas.numberSchema,
+        schemas.jsNumber,
+      ]);
+      if (defaultBlock !== undefined) {
+        assert.isBlockParam('defaultBlock', defaultBlock);
+      }
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('proposeUsageCost(uint256)', [_usageCostProposed]);
+      const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...callData,
+          data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+      );
+      callDataWithDefaults.from = callDataWithDefaults.from
+        ? callDataWithDefaults.from.toLowerCase()
+        : callDataWithDefaults.from;
+
+      const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
+      BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
+      const abiEncoder = self._lookupAbiEncoder('proposeUsageCost(uint256)');
+      // tslint:disable boolean-naming
+      const result = abiEncoder.strictDecodeReturnValue<void>(rawCallResult);
+      // tslint:enable boolean-naming
+      return result;
+    },
+    getABIEncodedTransactionData(_usageCostProposed: BigNumber): string {
+      assert.isBigNumber('_usageCostProposed', _usageCostProposed);
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const abiEncodedTransactionData = self._strictEncodeArguments('proposeUsageCost(uint256)', [_usageCostProposed]);
       return abiEncodedTransactionData;
     },
   };
@@ -219,6 +347,44 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
       assert.isString('_module', _module);
       const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
       const abiEncodedTransactionData = self._strictEncodeArguments('upgrade(address)', [_module]);
+      return abiEncodedTransactionData;
+    },
+  };
+  public willCostInPoly = {
+    async callAsync(callData: Partial<CallData> = {}, defaultBlock?: BlockParam): Promise<boolean> {
+      assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+        schemas.addressSchema,
+        schemas.numberSchema,
+        schemas.jsNumber,
+      ]);
+      if (defaultBlock !== undefined) {
+        assert.isBlockParam('defaultBlock', defaultBlock);
+      }
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('willCostInPoly()', []);
+      const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...callData,
+          data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+      );
+      callDataWithDefaults.from = callDataWithDefaults.from
+        ? callDataWithDefaults.from.toLowerCase()
+        : callDataWithDefaults.from;
+
+      const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
+      BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
+      const abiEncoder = self._lookupAbiEncoder('willCostInPoly()');
+      // tslint:disable boolean-naming
+      const result = abiEncoder.strictDecodeReturnValue<boolean>(rawCallResult);
+      // tslint:enable boolean-naming
+      return result;
+    },
+    getABIEncodedTransactionData(): string {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const abiEncodedTransactionData = self._strictEncodeArguments('willCostInPoly()', []);
       return abiEncodedTransactionData;
     },
   };
@@ -775,6 +941,103 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
       return abiEncodedTransactionData;
     },
   };
+  public changeUsageCost = {
+    async sendTransactionAsync(
+      txData?: Partial<TxData> | undefined,
+      estimateGasFactor?: number,
+    ): Promise<PolyResponse> {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('changeUsageCost()', []);
+      const contractDefaults = self._web3Wrapper.getContractDefaults();
+      const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
+      const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...txData,
+          data: encodedData,
+        },
+        {
+          from: defaultFromAddress,
+          ...contractDefaults,
+        },
+        self.changeUsageCost.estimateGasAsync.bind<USDTieredSTOFactoryContract_3_1_0, any, Promise<number>>(
+          self,
+
+          estimateGasFactor,
+        ),
+      );
+      if (txDataWithDefaults.from !== undefined) {
+        txDataWithDefaults.from = txDataWithDefaults.from.toLowerCase();
+      }
+
+      const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+      const receipt = self._web3Wrapper.awaitTransactionSuccessAsync(txHash);
+
+      return new PolyResponse(txHash, receipt);
+    },
+    async estimateGasAsync(factor?: number, txData?: Partial<TxData> | undefined): Promise<number> {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('changeUsageCost()', []);
+      const contractDefaults = self._web3Wrapper.getContractDefaults();
+      const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
+      const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...txData,
+          data: encodedData,
+        },
+        {
+          from: defaultFromAddress,
+          ...contractDefaults,
+        },
+      );
+      if (txDataWithDefaults.from !== undefined) {
+        txDataWithDefaults.from = txDataWithDefaults.from.toLowerCase();
+      }
+
+      const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+      const networkGasLimit = (await self._web3Wrapper.getBlockWithTransactionDataAsync('latest')).gasLimit;
+      const _factor = factor === undefined ? self._defaultEstimateGasFactor : factor;
+      const _safetyGasEstimation = Math.round(_factor * gas);
+      return _safetyGasEstimation > networkGasLimit ? networkGasLimit : _safetyGasEstimation;
+    },
+    async callAsync(callData: Partial<CallData> = {}, defaultBlock?: BlockParam): Promise<void> {
+      assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+        schemas.addressSchema,
+        schemas.numberSchema,
+        schemas.jsNumber,
+      ]);
+      if (defaultBlock !== undefined) {
+        assert.isBlockParam('defaultBlock', defaultBlock);
+      }
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('changeUsageCost()', []);
+      const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...callData,
+          data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+      );
+      callDataWithDefaults.from = callDataWithDefaults.from
+        ? callDataWithDefaults.from.toLowerCase()
+        : callDataWithDefaults.from;
+
+      const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
+      BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
+      const abiEncoder = self._lookupAbiEncoder('changeUsageCost()');
+      // tslint:disable boolean-naming
+      const result = abiEncoder.strictDecodeReturnValue<void>(rawCallResult);
+      // tslint:enable boolean-naming
+      return result;
+    },
+    getABIEncodedTransactionData(): string {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const abiEncodedTransactionData = self._strictEncodeArguments('changeUsageCost()', []);
+      return abiEncodedTransactionData;
+    },
+  };
   public isCostInPoly = {
     async callAsync(callData: Partial<CallData> = {}, defaultBlock?: BlockParam): Promise<boolean> {
       assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
@@ -968,6 +1231,44 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
       assert.isBigNumber('index_0', index_0);
       const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
       const abiEncodedTransactionData = self._strictEncodeArguments('logicContracts(uint256)', [index_0]);
+      return abiEncodedTransactionData;
+    },
+  };
+  public usageCostProposedAt = {
+    async callAsync(callData: Partial<CallData> = {}, defaultBlock?: BlockParam): Promise<BigNumber> {
+      assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+        schemas.addressSchema,
+        schemas.numberSchema,
+        schemas.jsNumber,
+      ]);
+      if (defaultBlock !== undefined) {
+        assert.isBlockParam('defaultBlock', defaultBlock);
+      }
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('usageCostProposedAt()', []);
+      const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...callData,
+          data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+      );
+      callDataWithDefaults.from = callDataWithDefaults.from
+        ? callDataWithDefaults.from.toLowerCase()
+        : callDataWithDefaults.from;
+
+      const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
+      BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
+      const abiEncoder = self._lookupAbiEncoder('usageCostProposedAt()');
+      // tslint:disable boolean-naming
+      const result = abiEncoder.strictDecodeReturnValue<BigNumber>(rawCallResult);
+      // tslint:enable boolean-naming
+      return result;
+    },
+    getABIEncodedTransactionData(): string {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const abiEncodedTransactionData = self._strictEncodeArguments('usageCostProposedAt()', []);
       return abiEncodedTransactionData;
     },
   };
@@ -1561,17 +1862,120 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
       return abiEncodedTransactionData;
     },
   };
+  public changeCostType = {
+    async sendTransactionAsync(
+      txData?: Partial<TxData> | undefined,
+      estimateGasFactor?: number,
+    ): Promise<PolyResponse> {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('changeCostType()', []);
+      const contractDefaults = self._web3Wrapper.getContractDefaults();
+      const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
+      const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...txData,
+          data: encodedData,
+        },
+        {
+          from: defaultFromAddress,
+          ...contractDefaults,
+        },
+        self.changeCostType.estimateGasAsync.bind<USDTieredSTOFactoryContract_3_1_0, any, Promise<number>>(
+          self,
+
+          estimateGasFactor,
+        ),
+      );
+      if (txDataWithDefaults.from !== undefined) {
+        txDataWithDefaults.from = txDataWithDefaults.from.toLowerCase();
+      }
+
+      const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+      const receipt = self._web3Wrapper.awaitTransactionSuccessAsync(txHash);
+
+      return new PolyResponse(txHash, receipt);
+    },
+    async estimateGasAsync(factor?: number, txData?: Partial<TxData> | undefined): Promise<number> {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('changeCostType()', []);
+      const contractDefaults = self._web3Wrapper.getContractDefaults();
+      const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
+      const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...txData,
+          data: encodedData,
+        },
+        {
+          from: defaultFromAddress,
+          ...contractDefaults,
+        },
+      );
+      if (txDataWithDefaults.from !== undefined) {
+        txDataWithDefaults.from = txDataWithDefaults.from.toLowerCase();
+      }
+
+      const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+      const networkGasLimit = (await self._web3Wrapper.getBlockWithTransactionDataAsync('latest')).gasLimit;
+      const _factor = factor === undefined ? self._defaultEstimateGasFactor : factor;
+      const _safetyGasEstimation = Math.round(_factor * gas);
+      return _safetyGasEstimation > networkGasLimit ? networkGasLimit : _safetyGasEstimation;
+    },
+    async callAsync(callData: Partial<CallData> = {}, defaultBlock?: BlockParam): Promise<void> {
+      assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+        schemas.addressSchema,
+        schemas.numberSchema,
+        schemas.jsNumber,
+      ]);
+      if (defaultBlock !== undefined) {
+        assert.isBlockParam('defaultBlock', defaultBlock);
+      }
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('changeCostType()', []);
+      const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...callData,
+          data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+      );
+      callDataWithDefaults.from = callDataWithDefaults.from
+        ? callDataWithDefaults.from.toLowerCase()
+        : callDataWithDefaults.from;
+
+      const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
+      BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
+      const abiEncoder = self._lookupAbiEncoder('changeCostType()');
+      // tslint:disable boolean-naming
+      const result = abiEncoder.strictDecodeReturnValue<void>(rawCallResult);
+      // tslint:enable boolean-naming
+      return result;
+    },
+    getABIEncodedTransactionData(): string {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const abiEncodedTransactionData = self._strictEncodeArguments('changeCostType()', []);
+      return abiEncodedTransactionData;
+    },
+  };
   public changeCostAndType = {
     async sendTransactionAsync(
       _setupCost: BigNumber,
+      _usageCost: BigNumber,
       _isCostInPoly: boolean,
       txData?: Partial<TxData> | undefined,
       estimateGasFactor?: number,
     ): Promise<PolyResponse> {
       assert.isBigNumber('_setupCost', _setupCost);
+      assert.isBigNumber('_usageCost', _usageCost);
       assert.isBoolean('_isCostInPoly', _isCostInPoly);
       const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
-      const encodedData = self._strictEncodeArguments('changeCostAndType(uint256,bool)', [_setupCost, _isCostInPoly]);
+      const encodedData = self._strictEncodeArguments('changeCostAndType(uint256,uint256,bool)', [
+        _setupCost,
+        _usageCost,
+        _isCostInPoly,
+      ]);
       const contractDefaults = self._web3Wrapper.getContractDefaults();
       const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
       const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -1587,6 +1991,7 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
         self.changeCostAndType.estimateGasAsync.bind<USDTieredSTOFactoryContract_3_1_0, any, Promise<number>>(
           self,
           _setupCost,
+          _usageCost,
           _isCostInPoly,
           estimateGasFactor,
         ),
@@ -1602,14 +2007,20 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
     },
     async estimateGasAsync(
       _setupCost: BigNumber,
+      _usageCost: BigNumber,
       _isCostInPoly: boolean,
       factor?: number,
       txData?: Partial<TxData> | undefined,
     ): Promise<number> {
       assert.isBigNumber('_setupCost', _setupCost);
+      assert.isBigNumber('_usageCost', _usageCost);
       assert.isBoolean('_isCostInPoly', _isCostInPoly);
       const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
-      const encodedData = self._strictEncodeArguments('changeCostAndType(uint256,bool)', [_setupCost, _isCostInPoly]);
+      const encodedData = self._strictEncodeArguments('changeCostAndType(uint256,uint256,bool)', [
+        _setupCost,
+        _usageCost,
+        _isCostInPoly,
+      ]);
       const contractDefaults = self._web3Wrapper.getContractDefaults();
       const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
       const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -1635,11 +2046,13 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
     },
     async callAsync(
       _setupCost: BigNumber,
+      _usageCost: BigNumber,
       _isCostInPoly: boolean,
       callData: Partial<CallData> = {},
       defaultBlock?: BlockParam,
     ): Promise<void> {
       assert.isBigNumber('_setupCost', _setupCost);
+      assert.isBigNumber('_usageCost', _usageCost);
       assert.isBoolean('_isCostInPoly', _isCostInPoly);
       assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
         schemas.addressSchema,
@@ -1650,7 +2063,11 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
         assert.isBlockParam('defaultBlock', defaultBlock);
       }
       const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
-      const encodedData = self._strictEncodeArguments('changeCostAndType(uint256,bool)', [_setupCost, _isCostInPoly]);
+      const encodedData = self._strictEncodeArguments('changeCostAndType(uint256,uint256,bool)', [
+        _setupCost,
+        _usageCost,
+        _isCostInPoly,
+      ]);
       const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
         {
           to: self.address,
@@ -1665,18 +2082,20 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
 
       const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
       BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-      const abiEncoder = self._lookupAbiEncoder('changeCostAndType(uint256,bool)');
+      const abiEncoder = self._lookupAbiEncoder('changeCostAndType(uint256,uint256,bool)');
       // tslint:disable boolean-naming
       const result = abiEncoder.strictDecodeReturnValue<void>(rawCallResult);
       // tslint:enable boolean-naming
       return result;
     },
-    getABIEncodedTransactionData(_setupCost: BigNumber, _isCostInPoly: boolean): string {
+    getABIEncodedTransactionData(_setupCost: BigNumber, _usageCost: BigNumber, _isCostInPoly: boolean): string {
       assert.isBigNumber('_setupCost', _setupCost);
+      assert.isBigNumber('_usageCost', _usageCost);
       assert.isBoolean('_isCostInPoly', _isCostInPoly);
       const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
-      const abiEncodedTransactionData = self._strictEncodeArguments('changeCostAndType(uint256,bool)', [
+      const abiEncodedTransactionData = self._strictEncodeArguments('changeCostAndType(uint256,uint256,bool)', [
         _setupCost,
+        _usageCost,
         _isCostInPoly,
       ]);
       return abiEncodedTransactionData;
@@ -1836,6 +2255,141 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
         'updateLogicContract(uint256,string,address,bytes)',
         [_upgrade, _version, _logicContract, _upgradeData],
       );
+      return abiEncodedTransactionData;
+    },
+  };
+  public usageCost = {
+    async callAsync(callData: Partial<CallData> = {}, defaultBlock?: BlockParam): Promise<BigNumber> {
+      assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+        schemas.addressSchema,
+        schemas.numberSchema,
+        schemas.jsNumber,
+      ]);
+      if (defaultBlock !== undefined) {
+        assert.isBlockParam('defaultBlock', defaultBlock);
+      }
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('usageCost()', []);
+      const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...callData,
+          data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+      );
+      callDataWithDefaults.from = callDataWithDefaults.from
+        ? callDataWithDefaults.from.toLowerCase()
+        : callDataWithDefaults.from;
+
+      const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
+      BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
+      const abiEncoder = self._lookupAbiEncoder('usageCost()');
+      // tslint:disable boolean-naming
+      const result = abiEncoder.strictDecodeReturnValue<BigNumber>(rawCallResult);
+      // tslint:enable boolean-naming
+      return result;
+    },
+    getABIEncodedTransactionData(): string {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const abiEncodedTransactionData = self._strictEncodeArguments('usageCost()', []);
+      return abiEncodedTransactionData;
+    },
+  };
+  public usageCostInPoly = {
+    async sendTransactionAsync(
+      txData?: Partial<TxData> | undefined,
+      estimateGasFactor?: number,
+    ): Promise<PolyResponse> {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('usageCostInPoly()', []);
+      const contractDefaults = self._web3Wrapper.getContractDefaults();
+      const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
+      const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...txData,
+          data: encodedData,
+        },
+        {
+          from: defaultFromAddress,
+          ...contractDefaults,
+        },
+        self.usageCostInPoly.estimateGasAsync.bind<USDTieredSTOFactoryContract_3_1_0, any, Promise<number>>(
+          self,
+
+          estimateGasFactor,
+        ),
+      );
+      if (txDataWithDefaults.from !== undefined) {
+        txDataWithDefaults.from = txDataWithDefaults.from.toLowerCase();
+      }
+
+      const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+      const receipt = self._web3Wrapper.awaitTransactionSuccessAsync(txHash);
+
+      return new PolyResponse(txHash, receipt);
+    },
+    async estimateGasAsync(factor?: number, txData?: Partial<TxData> | undefined): Promise<number> {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('usageCostInPoly()', []);
+      const contractDefaults = self._web3Wrapper.getContractDefaults();
+      const defaultFromAddress = (await self._web3Wrapper.getAvailableAddressesAsync())[0];
+      const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...txData,
+          data: encodedData,
+        },
+        {
+          from: defaultFromAddress,
+          ...contractDefaults,
+        },
+      );
+      if (txDataWithDefaults.from !== undefined) {
+        txDataWithDefaults.from = txDataWithDefaults.from.toLowerCase();
+      }
+
+      const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+      const networkGasLimit = (await self._web3Wrapper.getBlockWithTransactionDataAsync('latest')).gasLimit;
+      const _factor = factor === undefined ? self._defaultEstimateGasFactor : factor;
+      const _safetyGasEstimation = Math.round(_factor * gas);
+      return _safetyGasEstimation > networkGasLimit ? networkGasLimit : _safetyGasEstimation;
+    },
+    async callAsync(callData: Partial<CallData> = {}, defaultBlock?: BlockParam): Promise<BigNumber> {
+      assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+        schemas.addressSchema,
+        schemas.numberSchema,
+        schemas.jsNumber,
+      ]);
+      if (defaultBlock !== undefined) {
+        assert.isBlockParam('defaultBlock', defaultBlock);
+      }
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('usageCostInPoly()', []);
+      const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...callData,
+          data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+      );
+      callDataWithDefaults.from = callDataWithDefaults.from
+        ? callDataWithDefaults.from.toLowerCase()
+        : callDataWithDefaults.from;
+
+      const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
+      BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
+      const abiEncoder = self._lookupAbiEncoder('usageCostInPoly()');
+      // tslint:disable boolean-naming
+      const result = abiEncoder.strictDecodeReturnValue<BigNumber>(rawCallResult);
+      // tslint:enable boolean-naming
+      return result;
+    },
+    getABIEncodedTransactionData(): string {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const abiEncodedTransactionData = self._strictEncodeArguments('usageCostInPoly()', []);
       return abiEncodedTransactionData;
     },
   };
@@ -2047,6 +2601,44 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
       return abiEncodedTransactionData;
     },
   };
+  public proposedUsageCost = {
+    async callAsync(callData: Partial<CallData> = {}, defaultBlock?: BlockParam): Promise<BigNumber> {
+      assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+        schemas.addressSchema,
+        schemas.numberSchema,
+        schemas.jsNumber,
+      ]);
+      if (defaultBlock !== undefined) {
+        assert.isBlockParam('defaultBlock', defaultBlock);
+      }
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('proposedUsageCost()', []);
+      const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...callData,
+          data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+      );
+      callDataWithDefaults.from = callDataWithDefaults.from
+        ? callDataWithDefaults.from.toLowerCase()
+        : callDataWithDefaults.from;
+
+      const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
+      BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
+      const abiEncoder = self._lookupAbiEncoder('proposedUsageCost()');
+      // tslint:disable boolean-naming
+      const result = abiEncoder.strictDecodeReturnValue<BigNumber>(rawCallResult);
+      // tslint:enable boolean-naming
+      return result;
+    },
+    getABIEncodedTransactionData(): string {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const abiEncodedTransactionData = self._strictEncodeArguments('proposedUsageCost()', []);
+      return abiEncodedTransactionData;
+    },
+  };
   public getUpperSTVersionBounds = {
     async callAsync(callData: Partial<CallData> = {}, defaultBlock?: BlockParam): Promise<BigNumber[]> {
       assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
@@ -2082,6 +2674,44 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
     getABIEncodedTransactionData(): string {
       const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
       const abiEncodedTransactionData = self._strictEncodeArguments('getUpperSTVersionBounds()', []);
+      return abiEncodedTransactionData;
+    },
+  };
+  public changeInCostTypeAt = {
+    async callAsync(callData: Partial<CallData> = {}, defaultBlock?: BlockParam): Promise<BigNumber> {
+      assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+        schemas.addressSchema,
+        schemas.numberSchema,
+        schemas.jsNumber,
+      ]);
+      if (defaultBlock !== undefined) {
+        assert.isBlockParam('defaultBlock', defaultBlock);
+      }
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const encodedData = self._strictEncodeArguments('changeInCostTypeAt()', []);
+      const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+          to: self.address,
+          ...callData,
+          data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+      );
+      callDataWithDefaults.from = callDataWithDefaults.from
+        ? callDataWithDefaults.from.toLowerCase()
+        : callDataWithDefaults.from;
+
+      const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
+      BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
+      const abiEncoder = self._lookupAbiEncoder('changeInCostTypeAt()');
+      // tslint:disable boolean-naming
+      const result = abiEncoder.strictDecodeReturnValue<BigNumber>(rawCallResult);
+      // tslint:enable boolean-naming
+      return result;
+    },
+    getABIEncodedTransactionData(): string {
+      const self = (this as any) as USDTieredSTOFactoryContract_3_1_0;
+      const abiEncodedTransactionData = self._strictEncodeArguments('changeInCostTypeAt()', []);
       return abiEncodedTransactionData;
     },
   };
@@ -2323,6 +2953,7 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
     supportedProvider: SupportedProvider,
     txDefaults: Partial<TxData>,
     _setupCost: BigNumber,
+    _usageCost: BigNumber,
     _logicContract: string,
     _polymathRegistry: string,
     _isCostInPoly: boolean,
@@ -2335,14 +2966,20 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
     ]);
     const provider = providerUtils.standardizeOrThrow(supportedProvider);
     const constructorAbi = BaseContract._lookupConstructorAbi(abi);
-    [_setupCost, _logicContract, _polymathRegistry, _isCostInPoly] = BaseContract._formatABIDataItemList(
+    [_setupCost, _usageCost, _logicContract, _polymathRegistry, _isCostInPoly] = BaseContract._formatABIDataItemList(
       constructorAbi.inputs,
-      [_setupCost, _logicContract, _polymathRegistry, _isCostInPoly],
+      [_setupCost, _usageCost, _logicContract, _polymathRegistry, _isCostInPoly],
       BaseContract._bigNumberToString,
     );
     const iface = new ethersUtils.Interface(abi);
     const deployInfo = iface.deployFunction;
-    const txData = deployInfo.encode(bytecode, [_setupCost, _logicContract, _polymathRegistry, _isCostInPoly]);
+    const txData = deployInfo.encode(bytecode, [
+      _setupCost,
+      _usageCost,
+      _logicContract,
+      _polymathRegistry,
+      _isCostInPoly,
+    ]);
     const web3Wrapper = new Web3Wrapper(provider);
     const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
       { data: txData },
@@ -2358,7 +2995,7 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
       provider,
       txDefaults,
     );
-    contractInstance.constructorArgs = [_setupCost, _logicContract, _polymathRegistry, _isCostInPoly];
+    contractInstance.constructorArgs = [_setupCost, _usageCost, _logicContract, _polymathRegistry, _isCostInPoly];
     return contractInstance;
   }
 
@@ -2385,6 +3022,20 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
         constant: false,
         inputs: [
           {
+            name: '_usageCostProposed',
+            type: 'uint256',
+          },
+        ],
+        name: 'proposeUsageCost',
+        outputs: [],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        constant: false,
+        inputs: [
+          {
             name: '_module',
             type: 'address',
           },
@@ -2393,6 +3044,20 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
         outputs: [],
         payable: false,
         stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        constant: true,
+        inputs: [],
+        name: 'willCostInPoly',
+        outputs: [
+          {
+            name: '',
+            type: 'bool',
+          },
+        ],
+        payable: false,
+        stateMutability: 'view',
         type: 'function',
       },
       {
@@ -2468,6 +3133,15 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
           },
         ],
         name: 'setLogicContract',
+        outputs: [],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        constant: false,
+        inputs: [],
+        name: 'changeUsageCost',
         outputs: [],
         payable: false,
         stateMutability: 'nonpayable',
@@ -2550,6 +3224,20 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
           {
             name: 'upgradeData',
             type: 'bytes',
+          },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        constant: true,
+        inputs: [],
+        name: 'usageCostProposedAt',
+        outputs: [
+          {
+            name: '',
+            type: 'uint256',
           },
         ],
         payable: false,
@@ -2735,9 +3423,22 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
       },
       {
         constant: false,
+        inputs: [],
+        name: 'changeCostType',
+        outputs: [],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        constant: false,
         inputs: [
           {
             name: '_setupCost',
+            type: 'uint256',
+          },
+          {
+            name: '_usageCost',
             type: 'uint256',
           },
           {
@@ -2778,6 +3479,34 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
         type: 'function',
       },
       {
+        constant: true,
+        inputs: [],
+        name: 'usageCost',
+        outputs: [
+          {
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        constant: false,
+        inputs: [],
+        name: 'usageCostInPoly',
+        outputs: [
+          {
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
         constant: false,
         inputs: [
           {
@@ -2808,11 +3537,39 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
       {
         constant: true,
         inputs: [],
+        name: 'proposedUsageCost',
+        outputs: [
+          {
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        constant: true,
+        inputs: [],
         name: 'getUpperSTVersionBounds',
         outputs: [
           {
             name: '',
             type: 'uint8[]',
+          },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        constant: true,
+        inputs: [],
+        name: 'changeInCostTypeAt',
+        outputs: [
+          {
+            name: '',
+            type: 'uint256',
           },
         ],
         payable: false,
@@ -2841,6 +3598,10 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
         inputs: [
           {
             name: '_setupCost',
+            type: 'uint256',
+          },
+          {
+            name: '_usageCost',
             type: 'uint256',
           },
           {
@@ -2952,6 +3713,42 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
         anonymous: false,
         inputs: [
           {
+            name: '_oldUsageCost',
+            type: 'uint256',
+            indexed: false,
+          },
+          {
+            name: '_newUsageCost',
+            type: 'uint256',
+            indexed: false,
+          },
+        ],
+        name: 'ChangeUsageCost',
+        outputs: [],
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            name: '_proposedFee',
+            type: 'uint256',
+            indexed: false,
+          },
+          {
+            name: '_currentFee',
+            type: 'uint256',
+            indexed: false,
+          },
+        ],
+        name: 'UsageCostProposed',
+        outputs: [],
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
             name: '_isOldCostInPoly',
             type: 'bool',
             indexed: false,
@@ -2963,6 +3760,24 @@ export class USDTieredSTOFactoryContract_3_1_0 extends BaseContract {
           },
         ],
         name: 'ChangeCostType',
+        outputs: [],
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            name: '_proposedCostType',
+            type: 'bool',
+            indexed: false,
+          },
+          {
+            name: '_currentCostType',
+            type: 'bool',
+            indexed: false,
+          },
+        ],
+        name: 'ChangeCostTypeProposed',
         outputs: [],
         type: 'event',
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,10 +388,10 @@
   resolved "https://registry.yarnpkg.com/@polymathnetwork/contract-artifacts/-/contract-artifacts-3.0.0.tgz#cb339d8cd5bef87af81c2b51934dcfd169801ead"
   integrity sha512-W+ByOIukA1YVxIGcePIoccoUXXi+Ze1fyWnLNtcJfxrS24Y4Q1vJMqHoYszlRVOetGqVY0CDv1U00Q0r98gWXA==
 
-"@polymathnetwork/contract-artifacts-3-1-0@npm:@polymathnetwork/contract-artifacts@3.1.0-beta.2":
-  version "3.1.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@polymathnetwork/contract-artifacts/-/contract-artifacts-3.1.0-beta.2.tgz#ae8629687e1e2aceb28d345f0416972b3be93521"
-  integrity sha512-0vC9aqQ3vV7RdQw6SdSN4rxbRStTDS5l+q9bcomuA+ZIQTsmEcS/DDxj/b1sfXMgMI3JE4R433dtT0dm7NMuag==
+"@polymathnetwork/contract-artifacts-3-1-0@npm:@polymathnetwork/contract-artifacts@3.1.0-beta.3":
+  version "3.1.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@polymathnetwork/contract-artifacts/-/contract-artifacts-3.1.0-beta.3.tgz#8bce7569b87bc3fd158ae2cdc7dd5ee46ef42156"
+  integrity sha512-R7AJuaHV81DKAQALpnOFw33k5eWqqFB6UBIeeh8r/2eTtOlagATpXZpjMIrbCdO/KdHHmZRunGoR+P8bvhyGqw==
 
 "@semantic-release/changelog@^3.0.4":
   version "3.0.4"


### PR DESCRIPTION
the module is now available to be pegged with other fiat currency than usd

BREAKING CHANGE: Contract is now available to be pegged with other fiat currency. Configure function
is now accepting the contract address of the stable coins, the addresses of the custom oracles and
the symbol of the denominated currency.